### PR TITLE
CCAHT-11 setup types and mongoose schema

### DIFF
--- a/server/actions/User.ts
+++ b/server/actions/User.ts
@@ -1,0 +1,9 @@
+import mongoDb from '../index'
+import UserSchema from '../models/User'
+import { User } from '../../utils/types'
+
+export async function createUser(user: User) {
+  await mongoDb()
+
+  return await UserSchema.create(user)
+}

--- a/server/models/Attribute.ts
+++ b/server/models/Attribute.ts
@@ -1,0 +1,23 @@
+import { model, Schema, Document, models, Model } from 'mongoose'
+import { Attribute } from '../../utils/types'
+
+const AttributeSchema = new Schema({
+  name: {
+    type: String,
+    required: true,
+  },
+  // TODO: change from mixed to one of "text", "number" or string[]
+  possibleValues: {
+    type: Schema.Types.Mixed,
+    required: true,
+  },
+  color: {
+    type: String,
+    required: true,
+  },
+})
+
+export interface AttributeDocument extends Omit<Attribute, '_id'>, Document {}
+
+export default (models.Attribute as Model<AttributeDocument>) ||
+  model<AttributeDocument>('Attribute', AttributeSchema)

--- a/server/models/Category.ts
+++ b/server/models/Category.ts
@@ -1,0 +1,14 @@
+import { model, Schema, Document, models, Model } from 'mongoose'
+import { Category } from '../../utils/types'
+
+const CategorySchema = new Schema({
+  name: {
+    type: String,
+    required: true,
+  },
+})
+
+export interface CategoryDocument extends Omit<Category, '_id'>, Document {}
+
+export default (models.Category as Model<CategoryDocument>) ||
+  model<CategoryDocument>('Category', CategorySchema)

--- a/server/models/InventoryItem.ts
+++ b/server/models/InventoryItem.ts
@@ -1,0 +1,34 @@
+import { model, Schema, Document, models, Model } from 'mongoose'
+import { InventoryItem } from '../../utils/types'
+
+const InventoryItemSchema = new Schema({
+  itemDefinition: {
+    type: { type: Schema.Types.ObjectId, ref: 'ItemDefinition' },
+    required: true,
+  },
+  attributeIds: {
+    type: [{ type: Schema.Types.ObjectId, ref: 'Attribute' }],
+    required: false,
+    default: [],
+  },
+  attributeValues: {
+    type: [String],
+    required: false,
+    default: [],
+  },
+  quantity: {
+    type: Number,
+    required: true,
+  },
+  assignee: {
+    type: { type: Schema.Types.ObjectId, ref: 'User' },
+    required: false,
+  },
+})
+
+export interface InventoryItemDocument
+  extends Omit<InventoryItem, '_id'>,
+    Document {}
+
+export default (models.InventoryItem as Model<InventoryItemDocument>) ||
+  model<InventoryItemDocument>('InventoryItem', InventoryItemSchema)

--- a/server/models/InventoryItem.ts
+++ b/server/models/InventoryItem.ts
@@ -1,18 +1,24 @@
 import { model, Schema, Document, models, Model } from 'mongoose'
 import { InventoryItem } from '../../utils/types'
 
+const attributeValueSchema = new Schema({
+  attribute: {
+    type: { type: Schema.Types.ObjectId, ref: 'Attribute' },
+    required: true,
+  },
+  value: {
+    type: Schema.Types.Mixed,
+    required: true,
+  },
+})
+
 const InventoryItemSchema = new Schema({
   itemDefinition: {
     type: { type: Schema.Types.ObjectId, ref: 'ItemDefinition' },
     required: true,
   },
-  attributeIds: {
-    type: [{ type: Schema.Types.ObjectId, ref: 'Attribute' }],
-    required: false,
-    default: [],
-  },
-  attributeValues: {
-    type: [String],
+  attributes: {
+    type: [attributeValueSchema],
     required: false,
     default: [],
   },

--- a/server/models/ItemDefinition.ts
+++ b/server/models/ItemDefinition.ts
@@ -1,0 +1,38 @@
+import { model, Schema, Document, models, Model } from 'mongoose'
+import { ItemDefinition } from '../../utils/types'
+
+const ItemDefinitionSchema = new Schema({
+  name: {
+    type: String,
+    required: true,
+  },
+  category: {
+    type: { type: Schema.Types.ObjectId, ref: 'Category' },
+    required: false,
+  },
+  attributes: {
+    type: [{ type: Schema.Types.ObjectId, ref: 'Attribute' }],
+    required: false,
+    default: [],
+  },
+  internal: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+  lowStockThreshold: {
+    type: Number,
+    required: true,
+  },
+  criticalStockThreshold: {
+    type: Number,
+    required: true,
+  },
+})
+
+export interface ItemDefinitionDocument
+  extends Omit<ItemDefinition, '_id'>,
+    Document {}
+
+export default (models.ItemDefinition as Model<ItemDefinitionDocument>) ||
+  model<ItemDefinitionDocument>('ItemDefinition', ItemDefinitionSchema)

--- a/server/models/ItemDefinition.ts
+++ b/server/models/ItemDefinition.ts
@@ -22,11 +22,13 @@ const ItemDefinitionSchema = new Schema({
   },
   lowStockThreshold: {
     type: Number,
-    required: true,
+    required: false,
+    default: -1,
   },
   criticalStockThreshold: {
     type: Number,
-    required: true,
+    required: false,
+    default: -1,
   },
 })
 

--- a/server/models/User.ts
+++ b/server/models/User.ts
@@ -1,0 +1,22 @@
+import { model, Schema, Document, models, Model } from 'mongoose'
+import { User } from '../../utils/types'
+
+const UserSchema = new Schema({
+  name: {
+    type: String,
+    required: true,
+  },
+  email: {
+    type: String,
+    required: true,
+  },
+  imageUrl: {
+    type: String,
+    required: true,
+  },
+})
+
+export interface UserDocument extends Omit<User, '_id'>, Document {}
+
+export default (models.User as Model<UserDocument>) ||
+  model<UserDocument>('User', UserSchema)

--- a/utils/types/api.ts
+++ b/utils/types/api.ts
@@ -1,0 +1,11 @@
+export class ApiError extends Error {
+  constructor(public statusCode: number, message: string) {
+    super(message)
+  }
+}
+
+export interface ApiResponse {
+  success: boolean
+  message?: string
+  data?: unknown
+}

--- a/utils/types/index.ts
+++ b/utils/types/index.ts
@@ -1,0 +1,2 @@
+export * from './models'
+export * from './api'

--- a/utils/types/models.ts
+++ b/utils/types/models.ts
@@ -10,6 +10,9 @@ export interface ItemDefinition {
   name: string
   category?: string | Category
   attributes?: (string | Attribute)[]
+  internal: boolean
+  lowStockThreshold: number
+  criticalStockThreshold: number
 }
 
 export interface InventoryItem {

--- a/utils/types/models.ts
+++ b/utils/types/models.ts
@@ -1,0 +1,34 @@
+export interface User {
+  _id?: string
+  name: string
+  email: string
+  imageUrl: string
+}
+
+export interface ItemDefinition {
+  _id?: string
+  name: string
+  category?: string | Category
+  attributes?: (string | Attribute)[]
+}
+
+export interface InventoryItem {
+  _id?: string
+  itemDefinition: string | ItemDefinition
+  attributeIds: string[]
+  attributeValues: string[]
+  quantity: number
+  assignee: string | User
+}
+
+export interface Category {
+  _id?: string
+  name: string
+}
+
+export interface Attribute {
+  _id?: string
+  name: string
+  possibleValues: 'test' | 'number' | string[]
+  color: string
+}

--- a/utils/types/models.ts
+++ b/utils/types/models.ts
@@ -18,8 +18,10 @@ export interface ItemDefinition {
 export interface InventoryItem {
   _id?: string
   itemDefinition: string | ItemDefinition
-  attributeIds: string[]
-  attributeValues: string[]
+  attributes?: {
+    attribute: string | Attribute
+    value: string | number
+  }[]
   quantity: number
   assignee: string | User
 }

--- a/utils/types/models.ts
+++ b/utils/types/models.ts
@@ -34,6 +34,6 @@ export interface Category {
 export interface Attribute {
   _id?: string
   name: string
-  possibleValues: 'test' | 'number' | string[]
+  possibleValues: 'text' | 'number' | string[]
   color: string
 }


### PR DESCRIPTION
This PR adds the schema definitions for mongoose/MongoDB into the `server/models` folder. They match up with the description from [CCAHT-11](https://team-16679321250140.atlassian.net/browse/CCAHT-11) exactly.

In the `utils/types` folder I created three files:
-  `models.ts` contains our model types and are used in the mongoose schema definitions to export the `[Entity]Document` interface.
- `api.ts` defines an `ApiError` class which will be useful for error handling, along with an interface for an `ApiResponse` which will be returned on all API requests.
- `index.ts` exports everything from the other two files, allowing the types to be imported using the following syntax:
```js
import { [type] } from '@/utils/types'
```
(The '@' symbol just means the root of the project, when actually importing you will need to use the path relative to the location of the file you are importing from)

**Note**: For the `Attribute` schema in mongoose, I wasn't able to define the `possibleValues` as taking on one of `"text"`, `"number"` or `string[]` and just used `Schema.Types.Mixed` which allows anything to go into the field. However, the `Attribute` defined in `utils/types/models.ts` does require one of those 3 possibilities so I don't think this will be an issue. Just something to be aware of.