### PR TITLE
CCAHT-65-create-utility-for-adding-query-params-to-a-url

### DIFF
--- a/pages/test.tsx
+++ b/pages/test.tsx
@@ -3,9 +3,6 @@ import { useEffect, useState } from 'react'
 import { addURLQueryParam, removeURLQueryParam } from '../utils/queryParams'
 
 export default function Test() {
-  const router = useRouter()
-  const [path, setPath] = useState("")
-
   // IMPORTANT
   // router.query isn't really updated until router.push() or router.replace() is called
   // However, when called in the util functions, router.query is still outdated
@@ -14,31 +11,25 @@ export default function Test() {
   // This has to due with how nextjs router is made and timings/refreshing the page
   // The workaround is to wait for the router object itself to update in a useEffect
   // Here is how I would access the path in code -- I would just use a state variable
+  const router = useRouter()
+  const [path, setPath] = useState("")
   useEffect(() => setPath(router.asPath), [router])
 
   // proof that this works:
   useEffect(() => console.log(path), [path])
 
-  // Test functions made to test out the util functions
-  const addParam = (key: string) => {
-    addURLQueryParam(router, key, 'test')
-  }
-
-  const removeParam = (key: string) => {
-    removeURLQueryParam(router, key)
-  }
 
   return (
     <>
-      <button onClick={() => addParam('hi1')}>add key 1</button>
-      <button onClick={() => addParam('hi2')}>add key 2</button>
-      <button onClick={() => addParam('hi3')}>add key 3</button>
-      <button onClick={() => addParam('hi4')}>add key 4</button>
-      <button onClick={() => addParam('hi5')}>add key 5</button>
+      <button onClick={() => addURLQueryParam(router, "hi1", "test")}>add key 1</button>
+      <button onClick={() => addURLQueryParam(router, "hi2", "test")}>add key 2</button>
+      <button onClick={() => addURLQueryParam(router, "hi3", "test")}>add key 3</button>
+      <button onClick={() => addURLQueryParam(router, "hi4", "test")}>add key 4</button>
+      <button onClick={() => addURLQueryParam(router, "hi5", "test")}>add key 5</button>
 
-      <button onClick={() => removeParam('hi1')}>delete key 1</button>
-      <button onClick={() => removeParam('hi2')}>delete key 2</button>
-      <button onClick={() => removeParam('hi3')}>delete key 3</button>
+      <button onClick={() => removeURLQueryParam(router, "hi1")}>delete key 1</button>
+      <button onClick={() => removeURLQueryParam(router, "hi2")}>delete key 2</button>
+      <button onClick={() => removeURLQueryParam(router, "hi3")}>delete key 3</button>
     </>
   )
 }

--- a/pages/test.tsx
+++ b/pages/test.tsx
@@ -1,0 +1,44 @@
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import { addURLQueryParam, removeURLQueryParam } from '../utils/queryParams'
+
+export default function Test() {
+  const router = useRouter()
+  const [path, setPath] = useState("")
+
+  // IMPORTANT
+  // router.query isn't really updated until router.push() or router.replace() is called
+  // However, when called in the util functions, router.query is still outdated
+  // What happened was that hitting button 1 once would show that the path is /test
+  // but hitting it a SECOND time would then properly show that the path is /test?hi1=test
+  // This has to due with how nextjs router is made and timings/refreshing the page
+  // The workaround is to wait for the router object itself to update in a useEffect
+  // Here is how I would access the path in code -- I would just use a state variable
+  useEffect(() => setPath(router.asPath), [router])
+
+  // proof that this works:
+  useEffect(() => console.log(path), [path])
+
+  // Test functions made to test out the util functions
+  const addParam = (key: string) => {
+    addURLQueryParam(router, key, 'test')
+  }
+
+  const removeParam = (key: string) => {
+    removeURLQueryParam(router, key)
+  }
+
+  return (
+    <>
+      <button onClick={() => addParam('hi1')}>add key 1</button>
+      <button onClick={() => addParam('hi2')}>add key 2</button>
+      <button onClick={() => addParam('hi3')}>add key 3</button>
+      <button onClick={() => addParam('hi4')}>add key 4</button>
+      <button onClick={() => addParam('hi5')}>add key 5</button>
+
+      <button onClick={() => removeParam('hi1')}>delete key 1</button>
+      <button onClick={() => removeParam('hi2')}>delete key 2</button>
+      <button onClick={() => removeParam('hi3')}>delete key 3</button>
+    </>
+  )
+}

--- a/utils/queryParams.ts
+++ b/utils/queryParams.ts
@@ -1,14 +1,26 @@
 import { NextRouter } from 'next/router'
 
 /**
+ * How to keep track of path in code:
+ * The router.query property is not updated right away when router.replace() or router.push() is called.
+ * Thus, it is necesarry to use a state variable and update it in your component whenever router is changed to
+ * access the path:
+ *
+ * const router = useRouter()
+ * const [path, setPath] = useState("")
+ * useEffect(() => setPath(router.asPath), [router])
+ */
+
+/**
  * If the input parameter is not already present, this function adds a query parameter to the current URL
  * @param router a NextJS router made using the useRouter() hook
  * @param key The key for the query parameter
  * @param val The value for the query parameter
  *
  * Usage:
- * If you are on localhost:3000/authenticationTest, calling addURLQueryParam("test", "hi") will
+ * - If you are on localhost:3000/authenticationTest, calling addURLQueryParam("test", "hi") will
  * change your url to localhost:3000/authenticationTest/?test=hi
+ * - See file for more details on keeping track of path.
  */
 export function addURLQueryParam(router: NextRouter, key: string, val: string) {
   if (!router.query[key]) {
@@ -22,6 +34,11 @@ export function addURLQueryParam(router: NextRouter, key: string, val: string) {
  * Deletes a given query parameter from the current URL
  * @param router a NextJS router made using the useRouter() hook
  * @param key The key for the query parameter that is to be deleted
+ *
+ * Usage:
+ * - If you are on localhost:3000/authenticationTest?test=hi, calling removeURLQueryParam("test") will
+ * change your url to localhost:3000/authenticationTest
+ * - See file for more details on keeping track of path.
  */
 export function removeURLQueryParam(router: NextRouter, key: string) {
   delete router.query[key]

--- a/utils/queryParams.ts
+++ b/utils/queryParams.ts
@@ -1,0 +1,32 @@
+import { NextRouter } from 'next/router'
+
+/**
+ * If the input parameter is not already present, this function adds a query parameter to the current URL
+ * @param router a NextJS router made using the useRouter() hook
+ * @param key The key for the query parameter
+ * @param val The value for the query parameter
+ *
+ * Usage:
+ * If you are on localhost:3000/authenticationTest, calling addURLQueryParam("test", "hi") will
+ * change your url to localhost:3000/authenticationTest/?test=hi
+ */
+export function addURLQueryParam(router: NextRouter, key: string, val: string) {
+  if (!router.query[key]) {
+    router.replace({
+      query: { ...router.query, [key]: val },
+    })
+  }
+}
+
+/**
+ * Deletes a given query parameter from the current URL
+ * @param router a NextJS router made using the useRouter() hook
+ * @param key The key for the query parameter that is to be deleted
+ */
+export function removeURLQueryParam(router: NextRouter, key: string) {
+  delete router.query[key]
+
+  router.replace({
+    query: { ...router.query },
+  })
+}


### PR DESCRIPTION
This PR adds utility functions to add and remove query parameters to the current URL.
The function definitions are included in queryParams.ts
queryParams.ts also includes documentation on how you can keep track of the current path in a variable, as the implementation can be tricky due to the details of how Next.js's useRouter() works.

To test everything, go to /queryParamsTest
The file that defines that page will be deleted before merging.

