### PR TITLE
debounce package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "next-auth": "^4.18.8",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "ts-debounce": "^4.0.0",
         "typescript": "4.8.4"
       },
       "devDependencies": {
@@ -5749,6 +5750,11 @@
         "node": ">=12"
       }
     },
+    "node_modules/ts-debounce": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ts-debounce/-/ts-debounce-4.0.0.tgz",
+      "integrity": "sha512-+1iDGY6NmOGidq7i7xZGA4cm8DAa6fqdYcvO5Z6yBevH++Bdo9Qt/mN0TzHUgcCcKv1gmh9+W5dHqz8pMWbCbg=="
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -9973,6 +9979,11 @@
       "requires": {
         "punycode": "^2.1.1"
       }
+    },
+    "ts-debounce": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ts-debounce/-/ts-debounce-4.0.0.tgz",
+      "integrity": "sha512-+1iDGY6NmOGidq7i7xZGA4cm8DAa6fqdYcvO5Z6yBevH++Bdo9Qt/mN0TzHUgcCcKv1gmh9+W5dHqz8pMWbCbg=="
     },
     "tsconfig-paths": {
       "version": "3.14.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "next-auth": "^4.18.8",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "ts-debounce": "^4.0.0",
     "typescript": "4.8.4"
   },
   "devDependencies": {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/99493316/220501303-cc37a670-f827-4951-b776-97e49cca1791.png)

Here's how I tested this out in the screenshot above. There were typescript related issues with the link given in the story, so Andrew and I found a package that will cover the debounce characteristic. Be sure to run `npm install` to get the new package.
