### PR TITLE
CCAHT-78-Switch-imports-to-use-absolute-paths

### DIFF
--- a/components/CheckInOutForm/QuantityForm.tsx
+++ b/components/CheckInOutForm/QuantityForm.tsx
@@ -1,6 +1,6 @@
 import { Box, Typography, TextField, IconButton } from '@mui/material'
 import React from 'react'
-import colors from '../../utils/colors'
+import colors from 'utils/colors'
 import AddOutlinedIcon from '@mui/icons-material/AddOutlined'
 import RemoveOutlinedIcon from '@mui/icons-material/RemoveOutlined'
 

--- a/components/CheckInOutForm/index.tsx
+++ b/components/CheckInOutForm/index.tsx
@@ -2,8 +2,8 @@ import { Autocomplete, Box, FormControl, TextField } from '@mui/material'
 import { DateTimePicker } from '@mui/x-date-pickers'
 import dayjs, { Dayjs } from 'dayjs'
 import React from 'react'
-import { ItemDefinition, User } from '../../utils/types'
-import QuantityForm from './QuantityForm'
+import { ItemDefinition, User } from 'utils/types'
+import QuantityForm from 'components/CheckInOutForm/QuantityForm'
 
 interface Props {
   kioskMode: boolean

--- a/components/DefaultLayout/index.tsx
+++ b/components/DefaultLayout/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import NavigationDrawer from '../NavigationDrawer'
-import HeaderAppBar from '../HeaderAppBar'
+import NavigationDrawer from 'components/NavigationDrawer'
+import HeaderAppBar from 'components/HeaderAppBar'
 import Box from '@mui/material/Box'
 interface DefaultLayoutProps {
   children: React.ReactNode

--- a/components/NavigationDrawer/index.tsx
+++ b/components/NavigationDrawer/index.tsx
@@ -17,7 +17,7 @@ import UnarchiveOutlinedIcon from '@mui/icons-material/UnarchiveOutlined'
 import AssignmentLateOutlinedIcon from '@mui/icons-material/AssignmentLateOutlined'
 import AssignmentOutlinedIcon from '@mui/icons-material/AssignmentOutlined'
 // List component
-import NavigationDrawerListItem from './NavigationDrawerListItem'
+import NavigationDrawerListItem from 'components/NavigationDrawer/NavigationDrawerListItem'
 // List components from MUI
 import List from '@mui/material/List'
 import ListItemText from '@mui/material/ListItemText'
@@ -39,7 +39,7 @@ export default function NavigationDrawer({
   // Logo definition
   const logo = (
     <Image
-      src="/../public/images/CCAHT-Logo.png"
+      src="/images/CCAHT-Logo.png"
       alt="CCAHT-logo"
       height="70"
       width="239"

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,7 +1,7 @@
 import type { AppProps } from 'next/app'
 import { SessionProvider } from 'next-auth/react'
 import React from 'react'
-import DefaultLayout from '../components/DefaultLayout'
+import DefaultLayout from 'components/DefaultLayout'
 import { LocalizationProvider } from '@mui/x-date-pickers'
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
 

--- a/pages/api/attributes/[attributeId].ts
+++ b/pages/api/attributes/[attributeId].ts
@@ -1,12 +1,12 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { ApiError, Attribute } from '../../../utils/types'
-import { serverAuth } from '../../../utils/auth'
+import { ApiError, Attribute } from 'utils/types'
+import { serverAuth } from 'utils/auth'
 import {
   apiAttributeValidation,
   apiObjectIdValidation,
-} from '../../../utils/apiValidators'
-import * as MongoDriver from '../../../server/actions/MongoDriver'
-import AttributeSchema from '../../../server/models/Attribute'
+} from 'utils/apiValidators'
+import * as MongoDriver from 'server/actions/MongoDriver'
+import AttributeSchema from 'server/models/Attribute'
 
 // @route GET api/attributes/[attributeId] - Returns a single Attribute object given by a attributeId - Private
 // @route PUT api/attributes/[attributeId] - Updates an existing Attribute object (identified by attributeId) with a new Attribute object - Private

--- a/pages/api/attributes/index.ts
+++ b/pages/api/attributes/index.ts
@@ -1,9 +1,9 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { ApiError, Attribute } from '../../../utils/types'
-import { serverAuth } from '../../../utils/auth'
-import { apiAttributeValidation } from '../../../utils/apiValidators'
-import * as MongoDriver from '../../../server/actions/MongoDriver'
-import AttributeSchema from '../../../server/models/Attribute'
+import { ApiError, Attribute } from 'utils/types'
+import { serverAuth } from 'utils/auth'
+import { apiAttributeValidation } from 'utils/apiValidators'
+import * as MongoDriver from 'server/actions/MongoDriver'
+import AttributeSchema from 'server/models/Attribute'
 
 // @route GET api/attributes - Returns a list of all Attributes in the database - Private
 // @route POST api/attributes - Create an Attribute from request body - Private

--- a/pages/api/categories/[categoryId].ts
+++ b/pages/api/categories/[categoryId].ts
@@ -1,12 +1,12 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { ApiError, Category } from '../../../utils/types'
-import { serverAuth } from '../../../utils/auth'
+import { ApiError, Category } from 'utils/types'
+import { serverAuth } from 'utils/auth'
 import {
   apiCategoryValidation,
   apiObjectIdValidation,
-} from '../../../utils/apiValidators'
-import * as MongoDriver from '../../../server/actions/MongoDriver'
-import CategorySchema from '../../../server/models/Category'
+} from 'utils/apiValidators'
+import * as MongoDriver from 'server/actions/MongoDriver'
+import CategorySchema from 'server/models/Category'
 
 // @route GET api/categories/[categoryId] - Returns a single Category object given a categoryId - Private
 // @route PUT api/users/[categoryId] - Updates an existing Category object (identified by categoryId) with a new Category object - Private

--- a/pages/api/categories/index.ts
+++ b/pages/api/categories/index.ts
@@ -1,9 +1,9 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { ApiError, Category } from '../../../utils/types'
-import { serverAuth } from '../../../utils/auth'
-import { apiCategoryValidation } from '../../../utils/apiValidators'
-import * as MongoDriver from '../../../server/actions/MongoDriver'
-import CategorySchema from '../../../server/models/Category'
+import { ApiError, Category } from 'utils/types'
+import { serverAuth } from 'utils/auth'
+import { apiCategoryValidation } from 'utils/apiValidators'
+import * as MongoDriver from 'server/actions/MongoDriver'
+import CategorySchema from 'server/models/Category'
 
 // @route GET api/categories - Returns a list of all Categories in the database - Private
 // @route POST /api/categories - Create a category from request body - Private

--- a/pages/api/itemDefinitions/[itemDefinitionId].ts
+++ b/pages/api/itemDefinitions/[itemDefinitionId].ts
@@ -1,13 +1,13 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { getItemDefinition } from '../../../server/actions/ItemDefinition'
-import { ApiError, ItemDefinition } from '../../../utils/types'
-import { serverAuth } from '../../../utils/auth'
+import { getItemDefinition } from 'server/actions/ItemDefinition'
+import { ApiError, ItemDefinition } from 'utils/types'
+import { serverAuth } from 'utils/auth'
 import {
   apiItemDefinitionValidation,
   apiObjectIdValidation,
-} from '../../../utils/apiValidators'
-import * as MongoDriver from '../../../server/actions/MongoDriver'
-import ItemDefinitionSchema from '../../../server/models/Category'
+} from 'utils/apiValidators'
+import * as MongoDriver from 'server/actions/MongoDriver'
+import ItemDefinitionSchema from 'server/models/Category'
 
 // @route GET api/itemDefintions/[itemDefinitionId] - Returns a single ItemDefinition object given a itemDefinitionId - Private
 // @route PUT api/users/[itemDefinitionId] - Updates an existing ItemDefinition object (identified by itemDefinitionId) with a new ItemDefinition object - Private

--- a/pages/api/itemDefinitions/index.ts
+++ b/pages/api/itemDefinitions/index.ts
@@ -1,10 +1,10 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { ApiError, ItemDefinition } from '../../../utils/types'
-import { serverAuth } from '../../../utils/auth'
-import { apiItemDefinitionValidation } from '../../../utils/apiValidators'
-import * as MongoDriver from '../../../server/actions/MongoDriver'
-import ItemDefinitionSchema from '../../../server/models/ItemDefinition'
-import { getItemDefinitions } from '../../../server/actions/ItemDefinition'
+import { ApiError, ItemDefinition } from 'utils/types'
+import { serverAuth } from 'utils/auth'
+import { apiItemDefinitionValidation } from 'utils/apiValidators'
+import * as MongoDriver from 'server/actions/MongoDriver'
+import ItemDefinitionSchema from 'server/models/ItemDefinition'
+import { getItemDefinitions } from 'server/actions/ItemDefinition'
 
 // @route GET api/itemDefintions - Returns a list of all itemDefintions in the database - Private
 // @route POST /api/itemDefintions - Create a itemDefinition from request body - Private

--- a/pages/api/users/[userId].ts
+++ b/pages/api/users/[userId].ts
@@ -2,11 +2,11 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import {
   apiObjectIdValidation,
   apiUserValidation,
-} from '../../../utils/apiValidators'
-import { userEndpointServerAuth } from '../../../utils/auth'
-import { ApiError, User } from '../../../utils/types'
-import * as MongoDriver from '../../../server/actions/MongoDriver'
-import UserSchema from '../../../server/models/User'
+} from 'utils/apiValidators'
+import { userEndpointServerAuth } from 'utils/auth'
+import { ApiError, User } from 'utils/types'
+import * as MongoDriver from 'server/actions/MongoDriver'
+import UserSchema from 'server/models/User'
 
 // @route   GET api/users/[userId] - Returns a single User object for user with userId - Private
 // @route   DELETE api/users/[userId] - Deletes a single User object for user with userId - Private

--- a/pages/api/users/index.ts
+++ b/pages/api/users/index.ts
@@ -1,9 +1,9 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { ApiError, User } from '../../../utils/types'
-import { serverAuth } from '../../../utils/auth'
-import { apiUserValidation } from '../../../utils/apiValidators'
-import * as MongoDriver from '../../../server/actions/MongoDriver'
-import UserSchema from '../../../server/models/User'
+import { ApiError, User } from 'utils/types'
+import { serverAuth } from 'utils/auth'
+import { apiUserValidation } from 'utils/apiValidators'
+import * as MongoDriver from 'server/actions/MongoDriver'
+import UserSchema from 'server/models/User'
 
 // @route   POST /api/users - Create a user from request body. - Public
 export default async function handler(

--- a/server/actions/ItemDefinition.ts
+++ b/server/actions/ItemDefinition.ts
@@ -1,6 +1,6 @@
-import mongoDb from '../index'
-import ItemDefinitionSchema from '../models/ItemDefinition'
-import { getEntities, getEntity } from './MongoDriver'
+import mongoDb from 'server/index'
+import ItemDefinitionSchema from 'server/models/ItemDefinition'
+import { getEntities, getEntity } from 'server/actions/MongoDriver'
 
 /**
  * Finds an itemDefinition by its id

--- a/server/actions/MongoDriver.ts
+++ b/server/actions/MongoDriver.ts
@@ -1,7 +1,7 @@
-import mongoDb from '../index'
+import mongoDb from 'server/index'
 import { Document, FilterQuery, Model } from 'mongoose'
-import '../../utils/types'
-import { ApiError, ItemDefinition, ServerModel } from '../../utils/types'
+import 'utils/types'
+import { ApiError, ItemDefinition, ServerModel } from 'utils/types'
 
 const ENTITY_NOT_FOUND_MESSAGE = 'Entity does not exist'
 

--- a/server/models/Attribute.ts
+++ b/server/models/Attribute.ts
@@ -1,5 +1,5 @@
 import { model, Schema, Document, models, Model } from 'mongoose'
-import { Attribute } from '../../utils/types'
+import { Attribute } from 'utils/types'
 
 const AttributeSchema = new Schema({
   name: {

--- a/server/models/Category.ts
+++ b/server/models/Category.ts
@@ -1,5 +1,5 @@
 import { model, Schema, Document, models, Model } from 'mongoose'
-import { Category } from '../../utils/types'
+import { Category } from 'utils/types'
 
 const CategorySchema = new Schema({
   name: {

--- a/server/models/InventoryItem.ts
+++ b/server/models/InventoryItem.ts
@@ -1,5 +1,5 @@
 import { model, Schema, Document, models, Model } from 'mongoose'
-import { InventoryItem } from '../../utils/types'
+import { InventoryItem } from 'utils/types'
 
 const attributeValueSchema = new Schema({
   attribute: {

--- a/server/models/ItemDefinition.ts
+++ b/server/models/ItemDefinition.ts
@@ -1,5 +1,5 @@
 import { model, Schema, Document, models, Model } from 'mongoose'
-import { ItemDefinition } from '../../utils/types'
+import { ItemDefinition } from 'utils/types'
 
 const ItemDefinitionSchema = new Schema({
   name: {

--- a/server/models/User.ts
+++ b/server/models/User.ts
@@ -1,5 +1,5 @@
 import { model, Schema, Document, models, Model } from 'mongoose'
-import { User } from '../../utils/types'
+import { User } from 'utils/types'
 
 const UserSchema = new Schema({
   name: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,11 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@api/*": ["pages/api/*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]

--- a/utils/apiValidators.ts
+++ b/utils/apiValidators.ts
@@ -1,4 +1,4 @@
-import { ApiError } from './types'
+import { ApiError } from 'utils/types'
 import {
   validateAttribute,
   validateCategory,
@@ -6,7 +6,7 @@ import {
   validateObjectId,
   validateUser,
   ValidationResult,
-} from './validators'
+} from 'utils/validators'
 
 const BAD_REQUEST_BODY_PREFIX = 'Bad Request Body:\n'
 

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { unstable_getServerSession } from 'next-auth'
-import { authOptions } from '../pages/api/auth/[...nextauth]'
-import { ApiError } from './types'
+import { authOptions } from '@api/auth/[...nextauth]'
+import { ApiError } from 'utils/types'
 
 /**
  * This function ensures that the person making the server call is logged in AND that the email passed in as

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -1,5 +1,5 @@
 import createTheme from '@mui/material/styles/createTheme'
-import colors from './colors'
+import colors from 'utils/colors'
 
 const theme = createTheme({
   palette: {

--- a/utils/types/index.ts
+++ b/utils/types/index.ts
@@ -1,2 +1,2 @@
-export * from './models'
-export * from './api'
+export * from 'utils/types/models'
+export * from 'utils/types/api'


### PR DESCRIPTION
Edited tsconfig.json to support absolute paths and aliases. In some small cases, the paths got longer, however the majority of the paths got shorter and are easier to read.

A few notes:
- Use the alias `@api/` to access anything from `./pages/api/`
- When using the `Image` component from `next/image`, start the `src` path with a `/` and assume that you are already in `public/`
For example, with relative paths, the CCAHT logo would be: `/public/images/CCAHT-Logo.png`.\
Using absolute paths, that would be: `/images/CCAHT-Logo.png`. If you attempt to include `public/` you will get an error.

**Any open PR's and future changes after this PR is merged should use absolute paths.**
Also if there are any paths that are being used repetitively, we should consider making them an alias.