### PR TITLE
CCAHT-38-Add-category-dropdown-to-check-in-check-out-form-component

### DIFF
--- a/components/CheckInOutForm/index.tsx
+++ b/components/CheckInOutForm/index.tsx
@@ -2,21 +2,29 @@ import { Autocomplete, Box, FormControl, TextField } from '@mui/material'
 import { DateTimePicker } from '@mui/x-date-pickers'
 import dayjs, { Dayjs } from 'dayjs'
 import React from 'react'
-import { ItemDefinition, User } from 'utils/types'
+import { Category, ItemDefinition, User } from 'utils/types'
 import QuantityForm from 'components/CheckInOutForm/QuantityForm'
 
 interface Props {
   kioskMode: boolean
   users: User[]
   itemDefinitions: ItemDefinition[]
+  categories: Category[]
 }
 
-function CheckInOutForm({ kioskMode, users, itemDefinitions }: Props) {
+function CheckInOutForm({
+  kioskMode,
+  users,
+  itemDefinitions,
+  categories,
+}: Props) {
   const [date, setDate] = React.useState<Dayjs | null>(dayjs(new Date()))
   const [quantity, setQuantity] = React.useState<number>(1)
   const [selectedStaff, setSelectedStaff] = React.useState<User | null>()
   const [selectedItemDefinition, setSelectedItemDefinition] =
     React.useState<ItemDefinition | null>()
+  const [selectedCategory, setSelectedCategory] =
+    React.useState<Category | null>()
 
   return (
     <FormControl fullWidth>
@@ -39,6 +47,13 @@ function CheckInOutForm({ kioskMode, users, itemDefinitions }: Props) {
           renderInput={(params) => <TextField {...params} fullWidth />}
         />
       </Box>
+      <Autocomplete
+        options={categories}
+        sx={{ marginTop: 4 }}
+        renderInput={(params) => <TextField {...params} label="Category" />}
+        onChange={(_e, Category) => setSelectedCategory(Category)}
+        getOptionLabel={(Category) => Category.name}
+      />
       <Autocomplete
         options={itemDefinitions}
         sx={{ marginTop: 4 }}

--- a/pages/checkIn.tsx
+++ b/pages/checkIn.tsx
@@ -46,6 +46,7 @@ export default function CheckInPage() {
                 kioskMode={true}
                 users={[]}
                 itemDefinitions={[]}
+                categories={[]}
               />
             </CardContent>
 

--- a/pages/checkOut.tsx
+++ b/pages/checkOut.tsx
@@ -27,6 +27,7 @@ export default function CheckOutPage() {
                 kioskMode={true}
                 users={[]}
                 itemDefinitions={[]}
+                categories={[]}
               />
             </CardContent>
 


### PR DESCRIPTION
- Added a category dropdown option in the `CheckInOutForm` component using the item dropdown for reference.
- Added a `categories` prop.
- Used `useState` to store the category selected, using the item `useState` as reference.
- Added `categories` to check in and check out pages.

~~*Draft pull request until CCAHT-24 is merged, so I can add the `categories` prop to it.*~~