### PR TITLE
CCAHT-39 Attributes!

### DIFF
--- a/components/AttributeAutocomplete/index.tsx
+++ b/components/AttributeAutocomplete/index.tsx
@@ -1,0 +1,94 @@
+import { SxProps } from '@mui/material'
+import { Autocomplete, Chip, TextField } from '@mui/material'
+import React from 'react'
+import { AttributeRequest, OptionsAttribute } from 'utils/types'
+
+interface AutocompleteAttributeOption {
+  id: string
+  label: string
+  value: string
+  color: string
+}
+
+interface Props {
+  attributes: OptionsAttribute[]
+  onChange?: (e: React.SyntheticEvent, attributes: AttributeRequest) => void
+  sx?: SxProps
+}
+
+function buildAutocompleteOptions(
+  attributes: OptionsAttribute[]
+): AutocompleteAttributeOption[] {
+  return attributes.reduce((acc, attribute) => {
+    const options = attribute.possibleValues.map((value) => ({
+      id: attribute._id!, // todo: remove when request and reponse objects are separated
+      label: attribute.name,
+      value,
+      color: attribute.color,
+    }))
+
+    return [...acc, ...options]
+  }, [] as AutocompleteAttributeOption[])
+}
+
+function buildAttributeRequest(
+  attributes: AutocompleteAttributeOption[]
+): AttributeRequest {
+  return attributes.reduce((acc, attribute) => {
+    const attrReq = {
+      [attribute.id]: attribute.value,
+    }
+
+    return { ...acc, ...attrReq }
+  }, {})
+}
+
+export default function AttributeAutocomplete({
+  attributes,
+  sx,
+  onChange,
+}: Props) {
+  const options = buildAutocompleteOptions(attributes)
+
+  return (
+    <Autocomplete
+      multiple
+      options={options}
+      groupBy={(option) => option.label}
+      getOptionLabel={(option) => option.value}
+      isOptionEqualToValue={(option, value) =>
+        option.value === value.value && option.label === value.label
+      }
+      renderTags={(tagValue, getTagProps) =>
+        tagValue.map((option, index) => (
+          <Chip
+            label={option.value}
+            style={{ backgroundColor: option.color }}
+            {...getTagProps({ index })}
+            key={option.id}
+          />
+        ))
+      }
+      // getOptionDisabled={(option) =>
+      //   selectedAttributes.findIndex((a) => a.label === option.label) !== -1
+      // }
+      renderInput={(params) => <TextField {...params} label="Attributes" />}
+      onChange={(e, attributes) => {
+        if (!attributes.length) {
+          if (!!onChange) onChange(e, {} as AttributeRequest)
+          return
+        }
+
+        const newAttr = attributes.pop() as AutocompleteAttributeOption
+        const idx = attributes.findIndex(
+          (a) => a.label == newAttr.label && a.value != newAttr.value
+        )
+        if (idx != -1) attributes[idx] = newAttr
+        else attributes.push(newAttr)
+
+        if (!!onChange) onChange(e, buildAttributeRequest(attributes))
+      }}
+      sx={sx}
+    />
+  )
+}

--- a/components/AttributeAutocomplete/index.tsx
+++ b/components/AttributeAutocomplete/index.tsx
@@ -76,10 +76,15 @@ export default function AttributeAutocomplete({
           return
         }
 
+        // get and remove most recent attribute (the one that triggered this event)
         const newAttr = attributes.pop() as AutocompleteAttributeOption
+
+        // check if there exists another attribute with the same label
         const idx = attributes.findIndex(
           (a) => a.label == newAttr.label && a.value != newAttr.value
         )
+
+        // if so, replace that attribute with the new one. otherwise re-append it to the attributes array
         if (idx != -1) attributes[idx] = newAttr
         else attributes.push(newAttr)
 

--- a/components/AttributeAutocomplete/index.tsx
+++ b/components/AttributeAutocomplete/index.tsx
@@ -1,7 +1,7 @@
 import { SxProps } from '@mui/material'
 import { Autocomplete, Chip, TextField } from '@mui/material'
 import React from 'react'
-import { AttributeRequest, OptionsAttribute } from 'utils/types'
+import { InventoryItemAttributeRequest, OptionsAttribute } from 'utils/types'
 
 interface AutocompleteAttributeOption {
   id: string
@@ -12,7 +12,10 @@ interface AutocompleteAttributeOption {
 
 interface Props {
   attributes: OptionsAttribute[]
-  onChange?: (e: React.SyntheticEvent, attributes: AttributeRequest) => void
+  onChange?: (
+    e: React.SyntheticEvent,
+    attributes: InventoryItemAttributeRequest[]
+  ) => void
   sx?: SxProps
 }
 
@@ -33,14 +36,11 @@ function buildAutocompleteOptions(
 
 function buildAttributeRequest(
   attributes: AutocompleteAttributeOption[]
-): AttributeRequest {
-  return attributes.reduce((acc, attribute) => {
-    const attrReq = {
-      [attribute.id]: attribute.value,
-    }
-
-    return { ...acc, ...attrReq }
-  }, {})
+): InventoryItemAttributeRequest[] {
+  return attributes.map((attribute) => ({
+    attribute: attribute.id,
+    value: attribute.value,
+  }))
 }
 
 export default function AttributeAutocomplete({
@@ -72,7 +72,7 @@ export default function AttributeAutocomplete({
       renderInput={(params) => <TextField {...params} label="Attributes" />}
       onChange={(e, attributes) => {
         if (!attributes.length) {
-          if (!!onChange) onChange(e, {} as AttributeRequest)
+          if (!!onChange) onChange(e, [] as InventoryItemAttributeRequest[])
           return
         }
 

--- a/components/AttributeAutocomplete/index.tsx
+++ b/components/AttributeAutocomplete/index.tsx
@@ -69,9 +69,6 @@ export default function AttributeAutocomplete({
           />
         ))
       }
-      // getOptionDisabled={(option) =>
-      //   selectedAttributes.findIndex((a) => a.label === option.label) !== -1
-      // }
       renderInput={(params) => <TextField {...params} label="Attributes" />}
       onChange={(e, attributes) => {
         if (!attributes.length) {

--- a/components/CheckInOutForm/index.tsx
+++ b/components/CheckInOutForm/index.tsx
@@ -2,21 +2,32 @@ import { Autocomplete, Box, FormControl, TextField } from '@mui/material'
 import { DateTimePicker } from '@mui/x-date-pickers'
 import dayjs, { Dayjs } from 'dayjs'
 import React from 'react'
-import { ItemDefinition, User } from 'utils/types'
+import { Attribute, AttributeRequest, ItemDefinition, User } from 'utils/types'
 import QuantityForm from 'components/CheckInOutForm/QuantityForm'
+import AttributeAutocomplete from 'components/AttributeAutocomplete'
+import { separateAttributes } from 'utils/attribute'
 
 interface Props {
   kioskMode: boolean
   users: User[]
   itemDefinitions: ItemDefinition[]
+  attributes?: Attribute[]
 }
 
-function CheckInOutForm({ kioskMode, users, itemDefinitions }: Props) {
+function CheckInOutForm({
+  kioskMode,
+  users,
+  itemDefinitions,
+  attributes,
+}: Props) {
   const [date, setDate] = React.useState<Dayjs | null>(dayjs(new Date()))
   const [quantity, setQuantity] = React.useState<number>(1)
   const [selectedStaff, setSelectedStaff] = React.useState<User | null>()
   const [selectedItemDefinition, setSelectedItemDefinition] =
     React.useState<ItemDefinition | null>()
+  const [selectedAttributes, setSelectedAttributes] =
+    React.useState<AttributeRequest>({})
+  const splitAttrs = separateAttributes(attributes)
 
   return (
     <FormControl fullWidth>
@@ -47,6 +58,13 @@ function CheckInOutForm({ kioskMode, users, itemDefinitions }: Props) {
           setSelectedItemDefinition(itemDefinition)
         }
         getOptionLabel={(itemDefinition) => itemDefinition.name}
+      />
+      <AttributeAutocomplete
+        attributes={splitAttrs.options}
+        sx={{ mt: 4 }}
+        onChange={(_e, attributes) => {
+          setSelectedAttributes(attributes)
+        }}
       />
       <QuantityForm quantity={quantity} setQuantity={setQuantity} />
     </FormControl>

--- a/pages/checkIn.tsx
+++ b/pages/checkIn.tsx
@@ -46,6 +46,7 @@ export default function CheckInPage() {
                 kioskMode={true}
                 users={[]}
                 itemDefinitions={[]}
+                attributes={[]}
               />
             </CardContent>
 

--- a/pages/checkOut.tsx
+++ b/pages/checkOut.tsx
@@ -27,6 +27,7 @@ export default function CheckOutPage() {
                 kioskMode={true}
                 users={[]}
                 itemDefinitions={[]}
+                attributes={[]}
               />
             </CardContent>
 

--- a/utils/attribute.ts
+++ b/utils/attribute.ts
@@ -4,15 +4,6 @@ import {
   OptionsAttribute,
   TextAttribute,
 } from 'utils/types/models'
-
-export function getOptionAttributes(
-  attributes: Attribute[]
-): OptionsAttribute[] {
-  return attributes.filter(
-    (attribute) => attribute.possibleValues instanceof Array
-  ) as OptionsAttribute[]
-}
-
 export interface SeparatedAttributes {
   options: OptionsAttribute[]
   text: TextAttribute[]

--- a/utils/attribute.ts
+++ b/utils/attribute.ts
@@ -1,0 +1,44 @@
+import {
+  Attribute,
+  NumberAttribute,
+  OptionsAttribute,
+  TextAttribute,
+} from 'utils/types/models'
+
+export function getOptionAttributes(
+  attributes: Attribute[]
+): OptionsAttribute[] {
+  return attributes.filter(
+    (attribute) => attribute.possibleValues instanceof Array
+  ) as OptionsAttribute[]
+}
+
+export interface SeparatedAttributes {
+  options: OptionsAttribute[]
+  text: TextAttribute[]
+  number: NumberAttribute[]
+}
+
+export function separateAttributes(
+  attributes?: Attribute[]
+): SeparatedAttributes {
+  const defaultSplit: SeparatedAttributes = {
+    options: [],
+    text: [],
+    number: [],
+  }
+
+  if (!attributes) return defaultSplit
+
+  return attributes.reduce((acc, attribute) => {
+    if (attribute.possibleValues instanceof Array) {
+      acc.options = [...acc.options, attribute as OptionsAttribute]
+    } else if (attribute.possibleValues === 'text') {
+      acc.text = [...acc.text, attribute as TextAttribute]
+    } else if (attribute.possibleValues === 'number') {
+      acc.number = [...acc.number, attribute as NumberAttribute]
+    }
+
+    return acc
+  }, defaultSplit)
+}

--- a/utils/attribute.ts
+++ b/utils/attribute.ts
@@ -10,6 +10,11 @@ export interface SeparatedAttributes {
   number: NumberAttribute[]
 }
 
+/**
+ * Separates an array of Attributes based on the values they can hold.
+ * @param attributes The array of Attributes to separate.
+ * @returns A `SeparatedAttributes` object containing the different kinds of attributes.
+ */
 export function separateAttributes(
   attributes?: Attribute[]
 ): SeparatedAttributes {

--- a/utils/types/models.ts
+++ b/utils/types/models.ts
@@ -52,8 +52,9 @@ export interface NumberAttribute extends Attribute {
   possibleValues: 'number'
 }
 
-export interface AttributeRequest {
-  [_id: string]: string | number
+export interface InventoryItemAttributeRequest {
+  attribute: string
+  value: string | number
 }
 
 export type ServerModel =

--- a/utils/types/models.ts
+++ b/utils/types/models.ts
@@ -31,11 +31,29 @@ export interface Category {
   name: string
 }
 
+export type AttributePossibleValues = 'text' | 'number' | string[]
+
 export interface Attribute {
   _id?: string
   name: string
-  possibleValues: 'text' | 'number' | string[]
+  possibleValues: AttributePossibleValues
   color: string
+}
+
+export interface OptionsAttribute extends Attribute {
+  possibleValues: string[]
+}
+
+export interface TextAttribute extends Attribute {
+  possibleValues: 'text'
+}
+
+export interface NumberAttribute extends Attribute {
+  possibleValues: 'number'
+}
+
+export interface AttributeRequest {
+  [_id: string]: string | number
 }
 
 export type ServerModel =


### PR DESCRIPTION
- created some utility types in `utils/models.ts`
  - `OptionsAttribute`, `TextAttribute`, and `NumberAttribute` -- these types hold a specific type or value for their `possibleValues` field, useful when wanting to only accept a certain kind of attribute
  - `AttributePossibleValues` -- union type containing the types that a regular `Attribute`'s `possibleValues` field can hold
  - `AttributeRequest` -- the data that will be sent to the server when requesting an Attribute. This may need to be revisited.
 - created utility functions and types in `utils/attribute.ts`
   - `SeparatedAttributes` -- defines a type that contains each kind of attribute, keyed on the kind of attribute it is
   - `separateAttributes` -- splits the attributes by type and returns a `SeparatedAttributes` object
 - created `AttributeAutcomplete` component. This component takes in some `OptionsAttributes` and optional `sx` for styling, and an optional `onChange` for passing data.

To test, I created the following array of `Attribute` objects and passed them in to the `CheckInOutForm` component:

```ts
const attrs: Attribute[] = [
  {
    _id: '1',
    name: 'Color',
    possibleValues: ['Red', 'Blue', 'Green'],
    color: '#5e9cff',
  },
  {
    _id: '2',
    name: 'Size',
    possibleValues: ['Small', 'Medium', 'Large'],
    color: '#93fab7',
  },
  {
    _id: '3',
    name: 'Material',
    possibleValues: 'text',
    color: '#00ff00',
  },
]
```