### PR TITLE
Infers category from item in CheckInCheckOut

### DIFF
--- a/components/CheckInOutForm/index.tsx
+++ b/components/CheckInOutForm/index.tsx
@@ -40,6 +40,20 @@ function CheckInOutForm({
     React.useState<Category | null>()
   const splitAttrs = separateAttributes(attributes)
 
+  // if you select an item definition without selecting a category, infer the category
+  React.useEffect(() => {
+    // TODO: Update this when types are updated
+    if (
+      selectedCategory ||
+      !selectedItemDefinition ||
+      !selectedItemDefinition.category ||
+      typeof selectedItemDefinition.category === 'string'
+    ) {
+      return
+    }
+    setSelectedCategory(selectedItemDefinition.category)
+  }, [selectedItemDefinition, selectedCategory])
+
   return (
     <FormControl fullWidth>
       {/* Staff member, Date, and Item input fields */}
@@ -67,6 +81,7 @@ function CheckInOutForm({
         renderInput={(params) => <TextField {...params} label="Category" />}
         onChange={(_e, Category) => setSelectedCategory(Category)}
         getOptionLabel={(Category) => Category.name}
+        inputValue={selectedCategory ? selectedCategory.name : ''}
       />
       <Autocomplete
         options={itemDefinitions}


### PR DESCRIPTION
Clicking an item definition when a category is not selected updates the category to match the category of the item
To test, here's what I did
on /checkIn
![image](https://user-images.githubusercontent.com/85089368/224518169-9576f221-bb85-4d40-a3b5-9a712251d976.png)
And then pass the itemDefinitionTest into the itemDefinitions array of the CheckInCheckOut form