### PR TITLE
CCAHT-90 add category and attribute filtering

### DIFF
--- a/components/AttributeAutocomplete/index.tsx
+++ b/components/AttributeAutocomplete/index.tsx
@@ -3,7 +3,7 @@ import { Autocomplete, Chip, TextField } from '@mui/material'
 import React from 'react'
 import { InventoryItemAttributeRequest, OptionsAttribute } from 'utils/types'
 
-interface AutocompleteAttributeOption {
+export interface AutocompleteAttributeOption {
   id: string
   label: string
   value: string
@@ -16,12 +16,18 @@ interface Props {
     e: React.SyntheticEvent,
     attributes: InventoryItemAttributeRequest[]
   ) => void
+  value?: AutocompleteAttributeOption[]
+  setValue?: React.Dispatch<AutocompleteAttributeOption[]>
   sx?: SxProps
 }
 
 function buildAutocompleteOptions(
   attributes: OptionsAttribute[]
 ): AutocompleteAttributeOption[] {
+  if (!attributes) {
+    return [] as AutocompleteAttributeOption[]
+  }
+
   return attributes.reduce((acc, attribute) => {
     const options = attribute.possibleValues.map((value) => ({
       id: attribute._id!, // todo: remove when request and reponse objects are separated
@@ -47,6 +53,8 @@ export default function AttributeAutocomplete({
   attributes,
   sx,
   onChange,
+  value,
+  setValue,
 }: Props) {
   const options = buildAutocompleteOptions(attributes)
 
@@ -69,6 +77,7 @@ export default function AttributeAutocomplete({
           />
         ))
       }
+      value={value}
       renderInput={(params) => <TextField {...params} label="Attributes" />}
       onChange={(e, attributes) => {
         if (!attributes.length) {
@@ -89,6 +98,7 @@ export default function AttributeAutocomplete({
         else attributes.push(newAttr)
 
         if (!!onChange) onChange(e, buildAttributeRequest(attributes))
+        if (!!setValue) setValue(attributes)
       }}
       sx={sx}
     />

--- a/components/AttributeAutocomplete/index.tsx
+++ b/components/AttributeAutocomplete/index.tsx
@@ -80,6 +80,7 @@ export default function AttributeAutocomplete({
       value={value}
       renderInput={(params) => <TextField {...params} label="Attributes" />}
       onChange={(e, attributes) => {
+        if (!!setValue) setValue(attributes)
         if (!attributes.length) {
           if (!!onChange) onChange(e, [] as InventoryItemAttributeRequest[])
           return
@@ -98,7 +99,6 @@ export default function AttributeAutocomplete({
         else attributes.push(newAttr)
 
         if (!!onChange) onChange(e, buildAttributeRequest(attributes))
-        if (!!setValue) setValue(attributes)
       }}
       sx={sx}
     />

--- a/components/CheckInOutForm/index.tsx
+++ b/components/CheckInOutForm/index.tsx
@@ -19,7 +19,6 @@ interface Props {
   kioskMode: boolean
   users: User[]
   itemDefinitions: ItemDefinition[]
-  attributes: Attribute[]
   categories: Category[]
 }
 
@@ -29,7 +28,6 @@ function CheckInOutForm({
   kioskMode,
   users,
   itemDefinitions,
-  attributes,
   categories,
 }: Props) {
   const [date, setDate] = React.useState<Dayjs | null>(dayjs(new Date()))

--- a/pages/checkIn.tsx
+++ b/pages/checkIn.tsx
@@ -46,7 +46,6 @@ export default function CheckInPage() {
                 kioskMode={true}
                 users={[]}
                 itemDefinitions={[]}
-                attributes={[]}
                 categories={[]}
               />
             </CardContent>

--- a/pages/checkOut.tsx
+++ b/pages/checkOut.tsx
@@ -27,7 +27,6 @@ export default function CheckOutPage() {
                 kioskMode={true}
                 users={[]}
                 itemDefinitions={[]}
-                attributes={[]}
                 categories={[]}
               />
             </CardContent>


### PR DESCRIPTION
I implemented the filtering based on the category for item definitions. I also noticed I implemented the attributes field wrong, so I fixed that to use the selected item definitions attributes.

Here is the data I used to test:

```ts
const testCategories: Category[] = [
  {
    _id: '1',
    name: 'testCategory',
  },
  {
    _id: '2',
    name: 'testCategory2',
  },
]

const testItemDefinitions: ItemDefinition[] = [
  {
    _id: '1',
    name: 'testItemDefinition',
    category: testCategories[0],
    internal: true,
    lowStockThreshold: 10,
    criticalStockThreshold: 5,
    attributes: [
      {
        _id: '1',
        name: 'testAttribute',
        possibleValues: ['test1', 'test2'],
        color: '#FF0000',
      },
      {
        _id: '2',
        name: 'test2',
        possibleValues: 'number',
        color: '#00FF00',
      },
    ],
  },
  {
    _id: '2',
    name: 'testItemDefinition2',
    category: testCategories[1],
    internal: true,
    lowStockThreshold: 10,
    criticalStockThreshold: 5,
    attributes: [
      {
        _id: '1',
        name: 'testAttribute',
        possibleValues: ['test1', 'test2'],
        color: '#FF0000',
      },
      {
        _id: '2',
        name: 'test2',
        possibleValues: 'number',
        color: '#00FF00',
      },
    ],
  },
]
```