### PR TITLE
Ccaht 80 create mongo db test data setup script

### DIFF
--- a/utils/dbTestData.script
+++ b/utils/dbTestData.script
@@ -7,6 +7,7 @@ const categoryId4 = ObjectId();
 const categoryId5 = ObjectId();
 const categoryId6 = ObjectId();
 const categoryId7 = ObjectId();
+const categoryId8 = ObjectId();
 
 db.categories.insertMany(
     {
@@ -35,12 +36,12 @@ db.categories.insertMany(
     },
     {
         "_id": categoryId7,
-        "name": "Cleaning Supplies"
-    },
-    {
-        "_id": categoryId7,
         "name": "Linens"
     }
+    {
+        "_id": categoryId8,
+        "name": "Cleaning Supplies"
+    },
 );
 
 
@@ -154,6 +155,31 @@ const itemDefinitionId3 = ObjectId();
 const itemDefinitionId4 = ObjectId();
 const itemDefinitionId5 = ObjectId();
 const itemDefinitionId6 = ObjectId();
+const itemDefinitionId7 = ObjectId();
+const itemDefinitionId8 = ObjectId();
+const itemDefinitionId9 = ObjectId();
+const itemDefinitionId10 = ObjectId();
+const itemDefinitionId12 = ObjectId();
+const itemDefinitionId13 = ObjectId();
+const itemDefinitionId14 = ObjectId();
+const itemDefinitionId15 = ObjectId();
+const itemDefinitionId16 = ObjectId();
+const itemDefinitionId17 = ObjectId();
+const itemDefinitionId18 = ObjectId();
+const itemDefinitionId19 = ObjectId();
+const itemDefinitionId20 = ObjectId();
+const itemDefinitionId21 = ObjectId();
+const itemDefinitionId22 = ObjectId();
+const itemDefinitionId23 = ObjectId();
+const itemDefinitionId24 = ObjectId();
+const itemDefinitionId25 = ObjectId();
+const itemDefinitionId26 = ObjectId();
+const itemDefinitionId27 = ObjectId();
+const itemDefinitionId28 = ObjectId();
+const itemDefinitionId29 = ObjectId();
+const itemDefinitionId30 = ObjectId();
+const itemDefinitionId31 = ObjectId();
+const itemDefinitionId32 = ObjectId();
 
 db.itemDefinitions.insertMany(
     {

--- a/utils/dbTestData.script
+++ b/utils/dbTestData.script
@@ -1334,5 +1334,62 @@ db.inventoryItems.insertMany(
             }
         ],
         "quantity": 10
+    },
+
+    // shaving cream
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId11,
+        "attributes": [
+            {
+                "attribute": attributeId8,
+                "value": "8 oz"
+            }
+        ],
+        "quantity": 0
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId11,
+        "attributes": [
+            {
+                "attribute": attributeId8,
+                "value": "16 oz"
+            }
+        ],
+        "quantity": 40
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId11,
+        "attributes": [
+            {
+                "attribute": attributeId8,
+                "value": "24 oz"
+            }
+        ],
+        "quantity": 5
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId11,
+        "attributes": [
+            {
+                "attribute": attributeId8,
+                "value": "12 oz"
+            }
+        ],
+        "quantity": 15
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId11,
+        "attributes": [
+            {
+                "attribute": attributeId8,
+                "value": "32 oz"
+            }
+        ],
+        "quantity": 8
     }
 )

--- a/utils/dbTestData.script
+++ b/utils/dbTestData.script
@@ -169,291 +169,320 @@ db.itemDefinitions.insertMany(
         "_id": itemDefinitionId2,
         "name": "Pants",
         "category": categoryId1,
-        "attributes": [attributeId1],
+        "attributes": [attributeId3, attributeId4],
         "internal": false,
-        "lowStockThreshold": 20,
+        "lowStockThreshold": 15,
         "criticalStockThreshold": 10
     },
     {
-        "_id": itemDefinitionId2,
+        "_id": itemDefinitionId3,
         "name": "Shoes",
         "category": categoryId1,
-        "attributes": [attributeId1],
+        "attributes": [attributeId5, attributeId6],
         "internal": false,
-        "lowStockThreshold": 20,
-        "criticalStockThreshold": 10
+        "lowStockThreshold": 5,
+        "criticalStockThreshold": 2
     },
     {
-        "_id": itemDefinitionId2,
+        "_id": itemDefinitionId4,
         "name": "Bra",
         "category": categoryId1,
-        "attributes": [attributeId1],
+        "attributes": [attributeId7],
         "internal": false,
-        "lowStockThreshold": 20,
-        "criticalStockThreshold": 10
+        "lowStockThreshold": 5,
+        "criticalStockThreshold": 0
     },
     {
-        "_id": itemDefinitionId2,
+        "_id": itemDefinitionId5,
         "name": "Underwear",
         "category": categoryId1,
-        "attributes": [attributeId1],
+        "attributes": [],
         "internal": false,
-        "lowStockThreshold": 20,
+        "lowStockThreshold": 15,
         "criticalStockThreshold": 10
     },
     {
-        "_id": itemDefinitionId2,
+        "_id": itemDefinitionId6,
         "name": "Socks",
         "category": categoryId1,
-        "attributes": [attributeId1],
+        "attributes": [],
         "internal": false,
-        "lowStockThreshold": 20,
+        "lowStockThreshold": 30,
         "criticalStockThreshold": 10
     },
+
+
+
+
     {
-        "_id": itemDefinitionId2,
-        "name": "Oven",
-        "category": categoryId1,
-        "attributes": [attributeId1],
-        "internal": false,
-        "lowStockThreshold": 20,
-        "criticalStockThreshold": 10
-    },
-    {
-        "_id": itemDefinitionId2,
-        "name": "Mini Fridge",
-        "category": categoryId1,
-        "attributes": [attributeId1],
-        "internal": false,
-        "lowStockThreshold": 20,
-        "criticalStockThreshold": 10
-    },
-    {
-        "_id": itemDefinitionId2,
-        "name": "Refrigerator",
-        "category": categoryId1,
-        "attributes": [attributeId1],
-        "internal": false,
-        "lowStockThreshold": 20,
-        "criticalStockThreshold": 10
-    },
-    {
-        "_id": itemDefinitionId2,
-        "name": "Dishwasher",
-        "category": categoryId1,
-        "attributes": [attributeId1],
-        "internal": false,
-        "lowStockThreshold": 20,
-        "criticalStockThreshold": 10
-    },
-    {
-        "_id": itemDefinitionId2,
-        "name": "Coffee Maker",
-        "category": categoryId1,
-        "attributes": [attributeId1],
-        "internal": false,
-        "lowStockThreshold": 20,
-        "criticalStockThreshold": 10
-    },
-    {
-        "_id": itemDefinitionId2,
-        "name": "Toaster",
-        "category": categoryId1,
-        "attributes": [attributeId1],
-        "internal": false,
-        "lowStockThreshold": 20,
-        "criticalStockThreshold": 10
-    },
-    {
-        "_id": itemDefinitionId2,
-        "name": "Blender",
-        "category": categoryId1,
-        "attributes": [attributeId1],
-        "internal": false,
-        "lowStockThreshold": 20,
-        "criticalStockThreshold": 10
-    },
-    {
-        "_id": itemDefinitionId2,
-        "name": "Couch",
-        "category": categoryId1,
-        "attributes": [attributeId1],
-        "internal": false,
-        "lowStockThreshold": 20,
-        "criticalStockThreshold": 10
-    },
-    {
-        "_id": itemDefinitionId2,
-        "name": "Couch",
-        "category": categoryId4,
-        "attributes": [attributeId1],
-        "internal": false,
-        "lowStockThreshold": 20,
-        "criticalStockThreshold": 10
-    },
-    {
-        "_id": itemDefinitionId2,
-        "name": "Table",
-        "category": categoryId4,
-        "attributes": [attributeId1],
-        "internal": false,
-        "lowStockThreshold": 20,
-        "criticalStockThreshold": 10
-    },
-    {
-        "_id": itemDefinitionId2,
-        "name": "Chair",
-        "category": categoryId4,
-        "attributes": [attributeId1],
-        "internal": false,
-        "lowStockThreshold": 20,
-        "criticalStockThreshold": 10
-    },
-    {
-        "_id": itemDefinitionId2,
-        "name": "Laptop",
-        "category": categoryId4,
-        "attributes": [attributeId1],
-        "internal": false,
-        "lowStockThreshold": 20,
-        "criticalStockThreshold": 10
-    },
-    {
-        "_id": itemDefinitionId2,
-        "name": "Keyboard",
-        "category": categoryId4,
-        "attributes": [attributeId1],
-        "internal": false,
-        "lowStockThreshold": 20,
-        "criticalStockThreshold": 10
-    },
-    {
-        "_id": itemDefinitionId2,
-        "name": "Mouse",
-        "category": categoryId4,
-        "attributes": [attributeId1],
-        "internal": false,
-        "lowStockThreshold": 20,
-        "criticalStockThreshold": 10
-    },
-    {
-        "_id": itemDefinitionId2,
-        "name": "Monitor",
-        "category": categoryId4,
-        "attributes": [attributeId1],
-        "internal": false,
-        "lowStockThreshold": 20,
-        "criticalStockThreshold": 10
-    },
-    {
-        "_id": itemDefinitionId2,
-        "name": "Jumper Cables",
-        "category": categoryId4,
-        "attributes": [attributeId1],
-        "internal": false,
-        "lowStockThreshold": 20,
-        "criticalStockThreshold": 10
-    },
-    {
-        "_id": itemDefinitionId2,
-        "name": "Vacuum Cleaner",
-        "category": categoryId4,
-        "attributes": [attributeId1],
-        "internal": false,
-        "lowStockThreshold": 20,
-        "criticalStockThreshold": 10
-    },
-    {
-        "_id": itemDefinitionId2,
+        "_id": itemDefinitionId7,
         "name": "Shampoo",
-        "category": categoryId4,
-        "attributes": [attributeId1],
+        "category": categoryId2,
+        "attributes": [attributeId8],
         "internal": false,
-        "lowStockThreshold": 20,
+        "lowStockThreshold": 30,
         "criticalStockThreshold": 10
     },
     {
-        "_id": itemDefinitionId2,
+        "_id": itemDefinitionId8,
         "name": "Conditioner",
-        "category": categoryId4,
-        "attributes": [attributeId1],
+        "category": categoryId2,
+        "attributes": [attributeId8],
         "internal": false,
-        "lowStockThreshold": 20,
+        "lowStockThreshold": 30,
         "criticalStockThreshold": 10
     },
     {
-        "_id": itemDefinitionId2,
+        "_id": itemDefinitionId9,
         "name": "Soap",
-        "category": categoryId4,
-        "attributes": [attributeId1],
+        "category": categoryId2,
+        "attributes": [],
         "internal": false,
-        "lowStockThreshold": 20,
-        "criticalStockThreshold": 10
+        "lowStockThreshold": 50,
+        "criticalStockThreshold": 20
     },
     {
-        "_id": itemDefinitionId2,
+        "_id": itemDefinitionId10,
         "name": "Body Wash",
-        "category": categoryId4,
-        "attributes": [attributeId1],
+        "category": categoryId2,
+        "attributes": [attributeId8],
         "internal": false,
-        "lowStockThreshold": 20,
+        "lowStockThreshold": 30,
         "criticalStockThreshold": 10
     },
     {
-        "_id": itemDefinitionId2,
+        "_id": itemDefinitionId11,
         "name": "Shaving Cream",
-        "category": categoryId4,
-        "attributes": [attributeId1],
+        "category": categoryId2,
+        "attributes": [attributeId8],
         "internal": false,
-        "lowStockThreshold": 20,
+        "lowStockThreshold": 30,
         "criticalStockThreshold": 10
     },
     {
-        "_id": itemDefinitionId2,
+        "_id": itemDefinitionId12,
         "name": "Razor",
-        "category": categoryId4,
-        "attributes": [attributeId1],
+        "category": categoryId2,
+        "attributes": [],
         "internal": false,
-        "lowStockThreshold": 20,
+        "lowStockThreshold": 30,
         "criticalStockThreshold": 10
     },
+
+
+
+
     {
-        "_id": itemDefinitionId2,
+        "_id": itemDefinitionId13,
+        "name": "Couch",
+        "category": categoryId3,
+        "attributes": [attributeId10, attributeId14],
+        "internal": false,
+        "lowStockThreshold": 0,
+        "criticalStockThreshold": 0
+    },
+    {
+        "_id": itemDefinitionId14,
+        "name": "Table",
+        "category": categoryId3,
+        "attributes": [attributeId10, attributeId14],
+        "internal": false,
+        "lowStockThreshold": 0,
+        "criticalStockThreshold": 0
+    },
+    {
+        "_id": itemDefinitionId15,
+        "name": "Chair",
+        "category": categoryId3,
+        "attributes": [attributeId10, attributeId14],
+        "internal": false,
+        "lowStockThreshold": 0,
+        "criticalStockThreshold": 0
+    },
+
+
+
+
+    {
+        "_id": itemDefinitionId16,
+        "name": "Oven",
+        "category": categoryId4,
+        "attributes": [attributeId9, attributeId11, attributeId14],
+        "internal": false,
+        "lowStockThreshold": 0,
+        "criticalStockThreshold": 0
+    },
+    {
+        "_id": itemDefinitionId17,
+        "name": "Refrigerator",
+        "category": categoryId4,
+        "attributes": [attributeId9, attributeId11, attributeId14],
+        "internal": false,
+        "lowStockThreshold": 0,
+        "criticalStockThreshold": 0
+    },
+    {
+        "_id": itemDefinitionId18,
+        "name": "Dishwasher",
+        "category": categoryId4,
+        "attributes": [attributeId9, attributeId11, attributeId14],
+        "internal": false,
+        "lowStockThreshold": 0,
+        "criticalStockThreshold": 0
+    },
+
+
+
+
+
+
+    {
+        "_id": itemDefinitionId19,
+        "name": "Mini Fridge",
+        "category": categoryId5,
+        "attributes": [attributeId9, attributeId11, attributeId14],
+        "internal": false,
+        "lowStockThreshold": 0,
+        "criticalStockThreshold": 0
+    },
+    {
+        "_id": itemDefinitionId20,
+        "name": "Coffee Maker",
+        "category": categoryId5,
+        "attributes": [attributeId9, attributeId11, attributeId14],
+        "internal": false,
+        "lowStockThreshold": 0,
+        "criticalStockThreshold": 0
+    },
+    {
+        "_id": itemDefinitionId21,
+        "name": "Toaster",
+        "category": categoryId5,
+        "attributes": [attributeId9, attributeId11, attributeId14],
+        "internal": false,
+        "lowStockThreshold": 0,
+        "criticalStockThreshold": 0
+    },
+    {
+        "_id": itemDefinitionId22,
+        "name": "Blender",
+        "category": categoryId5,
+        "attributes": [attributeId9, attributeId11, attributeId14],
+        "internal": false,
+        "lowStockThreshold": 0,
+        "criticalStockThreshold": 0
+    },
+
+
+
+
+
+
+    {
+        "_id": itemDefinitionId23,
+        "name": "Laptop",
+        "category": categoryId6,
+        "attributes": [attributeId9, attributeId12],
+        "internal": true,
+        "lowStockThreshold": 0,
+        "criticalStockThreshold": 0
+    },
+    {
+        "_id": itemDefinitionId24,
+        "name": "Keyboard",
+        "category": categoryId6,
+        "attributes": [attributeId9, attributeId12],
+        "internal": true,
+        "lowStockThreshold": 0,
+        "criticalStockThreshold": 0
+    },
+    {
+        "_id": itemDefinitionId25,
+        "name": "Mouse",
+        "category": categoryId6,
+        "attributes": [attributeId9, attributeId12],
+        "internal": true,
+        "lowStockThreshold": 0,
+        "criticalStockThreshold": 0
+    },
+    {
+        "_id": itemDefinitionId26,
+        "name": "Monitor",
+        "category": categoryId6,
+        "attributes": [attributeId9, attributeId12],
+        "internal": true,
+        "lowStockThreshold": 0,
+        "criticalStockThreshold": 0
+    },
+
+
+
+
+
+
+
+    {
+        "_id": itemDefinitionId27,
+        "name": "Jumper Cables",
+        "attributes": [],
+        "internal": false,
+        "lowStockThreshold": 0,
+        "criticalStockThreshold": 0
+    },
+    {
+        "_id": itemDefinitionId28,
+        "name": "Vacuum Cleaner",
+        "attributes": [attributeId9],
+        "internal": false,
+        "lowStockThreshold": 0,
+        "criticalStockThreshold": 0
+    },
+    
+
+
+
+    {
+        "_id": itemDefinitionId29,
         "name": "Towel",
-        "category": categoryId4,
-        "attributes": [attributeId1],
+        "category": categoryId7,
+        "attributes": [],
         "internal": false,
-        "lowStockThreshold": 20,
-        "criticalStockThreshold": 10
+        "lowStockThreshold": 5,
+        "criticalStockThreshold": 0
     },
     {
-        "_id": itemDefinitionId2,
+        "_id": itemDefinitionId30,
         "name": "Bedsheet",
-        "category": categoryId4,
-        "attributes": [attributeId1],
+        "category": categoryId7,
+        "attributes": [attributeId13],
         "internal": false,
-        "lowStockThreshold": 20,
-        "criticalStockThreshold": 10
+        "lowStockThreshold": 0,
+        "criticalStockThreshold": 0
     },
     {
-        "_id": itemDefinitionId2,
+        "_id": itemDefinitionId31,
         "name": "Blanket",
-        "category": categoryId4,
-        "attributes": [attributeId1],
+        "category": categoryId7,
+        "attributes": [],
         "internal": false,
-        "lowStockThreshold": 20,
-        "criticalStockThreshold": 10
+        "lowStockThreshold": 10,
+        "criticalStockThreshold": 5
     },
     {
-        "_id": itemDefinitionId2,
+        "_id": itemDefinitionId32,
         "name": "Pillow",
-        "category": categoryId4,
-        "attributes": [attributeId1],
+        "category": categoryId7,
+        "attributes": [],
         "internal": false,
-        "lowStockThreshold": 20,
-        "criticalStockThreshold": 10
+        "lowStockThreshold": 10,
+        "criticalStockThreshold": 5
     }
 );
+
+
+
+
+
 
 db.inventoryItems.insertMany(
     {

--- a/utils/dbTestData.script
+++ b/utils/dbTestData.script
@@ -348,7 +348,7 @@ db.itemDefinitions.insertMany(
         "_id": itemDefinitionId17,
         "name": "Refrigerator",
         "category": categoryId4,
-        "attributes": [attributeId9, attributeId11, attributeId14],
+        "attributes": [attributeId9, attributeId10, attributeId14],
         "internal": false,
         "lowStockThreshold": 0,
         "criticalStockThreshold": 0
@@ -357,7 +357,7 @@ db.itemDefinitions.insertMany(
         "_id": itemDefinitionId18,
         "name": "Dishwasher",
         "category": categoryId4,
-        "attributes": [attributeId9, attributeId11, attributeId14],
+        "attributes": [attributeId9, attributeId10, attributeId14],
         "internal": false,
         "lowStockThreshold": 0,
         "criticalStockThreshold": 0
@@ -1497,6 +1497,126 @@ db.inventoryItems.insertMany(
             }
         ],
         "quantity": 1
+    },
+
+    // Oven
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId16,
+        "attributes": [
+            {
+                "attributeId": attributeId9,
+                "value": "Samsung"
+            },
+            {
+                "attributeId": attributeId11,
+                "value": "Electric"
+            },
+            {
+                "attributeId": attributeId14,
+                "value": "New"
+            }
+        ],
+        "quantity": 5
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId16,
+        "attributes": [
+            {
+                "attributeId": attributeId9,
+                "value": "LG"
+            },
+            {
+                "attributeId": attributeId11,
+                "value": "Gas"
+            },
+            {
+                "attributeId": attributeId14,
+                "value": "Used"
+            }
+        ],
+        "quantity": 3
+    },
+
+    // Refrigerator
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId17,
+        "attributes": [
+            {
+                "attributeId": attributeId9,
+                "value": "Whirlpool"
+            },
+            {
+                "attributeId": attributeId10,
+                "value": "French Door"
+            },
+            {
+                "attributeId": attributeId14,
+                "value": "New"
+            }
+        ],
+        "quantity": 2
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId17,
+        "attributes": [
+            {
+                "attributeId": attributeId9,
+                "value": "GE"
+            },
+            {
+                "attributeId": attributeId10,
+                "value": "Side-by-Side"
+            },
+            {
+                "attributeId": attributeId14,
+                "value": "Used"
+            }
+        ],
+        "quantity": 1
+    },
+
+    // Dishwasher
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId18,
+        "attributes": [
+            {
+                "attributeId": attributeId9,
+                "value": "Bosch"
+            },
+            {
+                "attributeId": attributeId10,
+                "value": "Built-in"
+            },
+            {
+                "attributeId": attributeId14,
+                "value": "New"
+            }
+        ],
+        "quantity": 4
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId18,
+        "attributes": [
+            {
+                "attributeId": attributeId9,
+                "value": "KitchenAid"
+            },
+            {
+                "attributeId": attributeId10,
+                "value": "Portable"
+            },
+            {
+                "attributeId": attributeId14,
+                "value": "Used"
+            }
+        ],
+        "quantity": 2
     },
 
 )

--- a/utils/dbTestData.script
+++ b/utils/dbTestData.script
@@ -70,98 +70,103 @@ const attributeId12 = ObjectId();
 const attributeId13 = ObjectId();
 const attributeId14 = ObjectId();
 const attributeId15 = ObjectId();
-const defaultColor = "#ebebeb";
+const color1 = "#ebebeb";
+const color2 = "#c7dbda";
+const color3 = "#e2f0cb";
+const color4 = "#55cbcd";
+const color5 = "#143f46";
+const color6 = "#ff6961";
 
 db.attributes.insertMany([
     {
         "_id": attributeId1,
         "name": "Top Size",
         "possibleValues": ["Small", "Medium", "Large", "Extra-Large"],
-        "color": defaultColor
+        "color": color1
     },
     {
         "_id": attributeId2,
         "name": "Shirt Type",
         "possibleValues": ["Short-Sleeve", "Long-Sleeve"],
-        "color": defaultColor
+        "color": color2
     },
     {
         "_id": attributeId3,
         "name": "Pants Length",
         "possibleValues": ["Shorts", "Long Pants"],
-        "color": defaultColor
+        "color": color3
     },
     {
         "_id": attributeId4,
         "name": "Pants Size",
         "possibleValues": "text",
-        "color": defaultColor
+        "color": color4
     },
     {
         "_id": attributeId5,
         "name": "Shoe Size",
         "possibleValues": "number",
-        "color": defaultColor
+        "color": color5
     },
     {
         "_id": attributeId6,
         "name": "Shoe Type",
         "possibleValues": "text",
-        "color": defaultColor
+        "color": color6
     },
     {
         "_id": attributeId7,
         "name": "Bra Size",
         "possibleValues": "text",
-        "color": defaultColor
+        "color": color1
     },
     {
         "_id": attributeId8,
         "name": "Toiletry Size",
         "possibleValues": "number",
-        "color": defaultColor
+        "color": color2
     },
     {
         "_id": attributeId9,
         "name": "Brand",
         "possibleValues": "text",
-        "color": defaultColor
+        "color": color3
     },
     {
         "_id": attributeId10,
         "name": "Type",
         "possibleValues": "text",
-        "color": defaultColor
+        "color": color4
     },
     {
         "_id": attributeId11,
         "name": "Oven Type",
         "possibleValues": ["Electric", "Gas"],
-        "color": defaultColor
+        "color": color5
     },
     {
         "_id": attributeId15,
         "name": "Serial Number",
         "possibleValues": "text",
-        "color": defaultColor
+        "color": color6
     },
     {
         "_id": attributeId12,
         "name": "Value",
         "possibleValues": "number",
-        "color": defaultColor
+        "color": color1
     },
     {
         "_id": attributeId13,
         "name": "Sheet Size",
         "possibleValues": ["Twin", "Twin XL", "Full", "Queen", "King"],
-        "color": defaultColor
+        "color": color2
     },
     {
         "_id": attributeId14,
         "name": "Condition",
         "possibleValues": ["New", "Used"],
-        "color": defaultColor
+        "color": color3
     },
 ]);
 
@@ -530,7 +535,9 @@ db.itemDefinitions.insertMany([
 
 
 
-
+const userId1 = ObjectId("63fcb70862199670ed36177a");
+const userId2 = ObjectId("63fa5c9265ada1f23e68b638");
+const userId3 = ObjectId("63f95a8a55d930aa6176f06b");
 
 
 // INVENTORY ITEMS
@@ -728,7 +735,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId5,
-                "value": "12"
+                "value": 12
             }, 
             {
                 "attribute": attributeId6,
@@ -743,7 +750,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId5,
-                "value": "4"
+                "value": 4
             }, 
             {
                 "attribute": attributeId6,
@@ -758,7 +765,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId5,
-                "value": "7"
+                "value": 7
             }, 
             {
                 "attribute": attributeId6,
@@ -773,7 +780,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId5,
-                "value": "8"
+                "value": 8
             }, 
             {
                 "attribute": attributeId6,
@@ -788,7 +795,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId5,
-                "value": "11"
+                "value": 11
             }, 
             {
                 "attribute": attributeId6,
@@ -803,7 +810,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId5,
-                "value": "12.5"
+                "value": 12.5
             }, 
             {
                 "attribute": attributeId6,
@@ -818,7 +825,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId5,
-                "value": "11.5"
+                "value": 11.5
             }, 
             {
                 "attribute": attributeId6,
@@ -833,7 +840,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId5,
-                "value": "12"
+                "value": 12
             }, 
             {
                 "attribute": attributeId6,
@@ -848,7 +855,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId5,
-                "value": "4"
+                "value": 4
             }, 
             {
                 "attribute": attributeId6,
@@ -863,7 +870,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId5,
-                "value": "7"
+                "value": 7
             }, 
             {
                 "attribute": attributeId6,
@@ -878,7 +885,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId5,
-                "value": "8"
+                "value": 8
             }, 
             {
                 "attribute": attributeId6,
@@ -893,7 +900,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId5,
-                "value": "11"
+                "value": 11
             }, 
             {
                 "attribute": attributeId6,
@@ -908,7 +915,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId5,
-                "value": "12.5"
+                "value": 12.5
             }, 
             {
                 "attribute": attributeId6,
@@ -923,7 +930,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId5,
-                "value": "11.5"
+                "value": 11.5
             }, 
             {
                 "attribute": attributeId6,
@@ -938,7 +945,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId5,
-                "value": "12"
+                "value": 12
             }, 
             {
                 "attribute": attributeId6,
@@ -953,7 +960,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId5,
-                "value": "4"
+                "value": 4
             }, 
             {
                 "attribute": attributeId6,
@@ -968,7 +975,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId5,
-                "value": "7"
+                "value": 7
             }, 
             {
                 "attribute": attributeId6,
@@ -983,7 +990,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId5,
-                "value": "8"
+                "value": 8
             }, 
             {
                 "attribute": attributeId6,
@@ -998,7 +1005,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId5,
-                "value": "11"
+                "value": 11
             }, 
             {
                 "attribute": attributeId6,
@@ -1013,7 +1020,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId5,
-                "value": "12.5"
+                "value": 12.5
             }, 
             {
                 "attribute": attributeId6,
@@ -1028,7 +1035,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId5,
-                "value": "11.5"
+                "value": 11.5
             }, 
             {
                 "attribute": attributeId6,
@@ -1181,7 +1188,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId8,
-                "value": "16 oz"
+                "value": 16
             }
         ],
         "quantity": 20
@@ -1192,7 +1199,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId8,
-                "value": "32 oz"
+                "value": 32
             }
         ],
         "quantity": 12
@@ -1203,7 +1210,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId8,
-                "value": "8 oz"
+                "value": 8
             }
         ],
         "quantity": 5
@@ -1214,7 +1221,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId8,
-                "value": "12 oz"
+                "value": 12
             }
         ],
         "quantity": 8
@@ -1225,7 +1232,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId8,
-                "value": "24 oz"
+                "value": 24
             }
         ],
         "quantity": 10
@@ -1238,7 +1245,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId8,
-                "value": "16 oz"
+                "value": 16
             }
         ],
         "quantity": 20
@@ -1249,7 +1256,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId8,
-                "value": "32 oz"
+                "value": 32
             }
         ],
         "quantity": 12
@@ -1260,7 +1267,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId8,
-                "value": "8 oz"
+                "value": 8
             }
         ],
         "quantity": 5
@@ -1271,7 +1278,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId8,
-                "value": "12 oz"
+                "value": 12
             }
         ],
         "quantity": 8
@@ -1282,7 +1289,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId8,
-                "value": "24 oz"
+                "value": 24
             }
         ],
         "quantity": 10
@@ -1302,7 +1309,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId8,
-                "value": "16 oz"
+                "value": 16
             }
         ],
         "quantity": 20
@@ -1313,7 +1320,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId8,
-                "value": "32 oz"
+                "value": 32
             }
         ],
         "quantity": 12
@@ -1324,7 +1331,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId8,
-                "value": "8 oz"
+                "value": 8
             }
         ],
         "quantity": 5
@@ -1335,7 +1342,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId8,
-                "value": "12 oz"
+                "value": 12
             }
         ],
         "quantity": 8
@@ -1346,7 +1353,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId8,
-                "value": "24 oz"
+                "value": 24
             }
         ],
         "quantity": 10
@@ -1359,7 +1366,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId8,
-                "value": "8 oz"
+                "value": 8
             }
         ],
         "quantity": 0
@@ -1370,7 +1377,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId8,
-                "value": "16 oz"
+                "value": 16
             }
         ],
         "quantity": 40
@@ -1381,7 +1388,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId8,
-                "value": "24 oz"
+                "value": 24
             }
         ],
         "quantity": 5
@@ -1392,7 +1399,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId8,
-                "value": "12 oz"
+                "value": 12
             }
         ],
         "quantity": 15
@@ -1403,7 +1410,7 @@ db.inventoryItems.insertMany([
         "attributes": [
             {
                 "attribute": attributeId8,
-                "value": "32 oz"
+                "value": 32
             }
         ],
         "quantity": 8
@@ -1891,7 +1898,7 @@ db.inventoryItems.insertMany([
             }
         ],
         "quantity": 1,
-        "assignee": ObjectId("63fcb70862199670ed36177a")
+        "assignee": userId1
     },
     {
         "_id": ObjectId(),
@@ -1902,7 +1909,7 @@ db.inventoryItems.insertMany([
             {"attribute": attributeId15, "value": "EFGH5678"}
         ],
         "quantity": 1,
-        "assignee": ObjectId("63fa5c9265ada1f23e68b638")
+        "assignee": userId2
     },
     {
         "_id": ObjectId(),
@@ -1913,7 +1920,7 @@ db.inventoryItems.insertMany([
             {"attribute": attributeId15, "value": "IJKL9012"}
         ],
         "quantity": 1,
-        "assignee": ObjectId("63f95a8a55d930aa6176f06b")
+        "assignee": userId3
     },
 
     //Keyboard
@@ -1926,7 +1933,7 @@ db.inventoryItems.insertMany([
             {"attribute": attributeId15, "value": "MNOP3456"}
         ],
         "quantity": 1,
-        "assignee": ObjectId("63fcb70862199670ed36177a")
+        "assignee": userId1
     },
     {
         "_id": ObjectId(),
@@ -1937,7 +1944,7 @@ db.inventoryItems.insertMany([
             {"attribute": attributeId15, "value": "QRST7890"}
         ],
         "quantity": 1,
-        "assignee": ObjectId("63fa5c9265ada1f23e68b638")
+        "assignee": userId2
     },
     {
         "_id": ObjectId(),
@@ -1948,7 +1955,7 @@ db.inventoryItems.insertMany([
             {"attribute": attributeId15, "value": "UVWX1234"}
         ],
         "quantity": 1,
-        "assignee": ObjectId("63f95a8a55d930aa6176f06b")
+        "assignee": userId3
     },
 
     // Mouse
@@ -1961,7 +1968,7 @@ db.inventoryItems.insertMany([
             {"attribute": attributeId15, "value": "ABCD1234"}
         ],
         "quantity": 1,
-        "assignee": ObjectId("63fcb70862199670ed36177a")
+        "assignee": userId1
     },
     {
         "_id": ObjectId(),
@@ -1972,7 +1979,7 @@ db.inventoryItems.insertMany([
             {"attribute": attributeId15, "value": "EFGH5678"}
         ],
         "quantity": 1,
-        "assignee": ObjectId("63fa5c9265ada1f23e68b638")
+        "assignee": userId2
     },
     {
         "_id": ObjectId(),
@@ -1983,7 +1990,7 @@ db.inventoryItems.insertMany([
             {"attribute": attributeId15, "value": "IJKL9012"}
         ],
         "quantity": 1,
-        "assignee": ObjectId("63f95a8a55d930aa6176f06b")
+        "assignee": userId3
     },
 
     // Monitor
@@ -1996,7 +2003,7 @@ db.inventoryItems.insertMany([
             {"attribute": attributeId15, "value": "MNOP3456"}
         ],
         "quantity": 1,
-        "assignee": ObjectId("63fcb70862199670ed36177a")
+        "assignee": userId1
     },
     {
         "_id": ObjectId(),
@@ -2007,7 +2014,7 @@ db.inventoryItems.insertMany([
             {"attribute": attributeId15, "value": "QRST7890"}
         ],
         "quantity": 1,
-        "assignee": ObjectId("63fa5c9265ada1f23e68b638")
+        "assignee": userid2
     },
     {
         "_id": ObjectId(),
@@ -2018,7 +2025,7 @@ db.inventoryItems.insertMany([
             {"attribute": attributeId15, "value": "UVWX1234"}
         ],
         "quantity": 1,
-        "assignee": ObjectId("63f95a8a55d930aa6176f06b")
+        "assignee": userId3
     },
 
 

--- a/utils/dbTestData.script
+++ b/utils/dbTestData.script
@@ -1403,17 +1403,18 @@ db.inventoryItems.insertMany(
     }, 
 
     // FURNITURE
+    // couch
     {
         "_id": ObjectId(),
         "itemDefinition": itemDefinitionId13,
         "attributes": [
             {
-            "attributeId": attributeId10,
-            "value": "Sectional"
+                "attributeId": attributeId10,
+                "value": "Sectional"
             },
             {
-            "attributeId": attributeId14,
-            "value": "Used"
+                "attributeId": attributeId14,
+                "value": "Used"
             }
         ],
         "quantity": 3
@@ -1423,16 +1424,79 @@ db.inventoryItems.insertMany(
         "itemDefinition": itemDefinitionId13,
         "attributes": [
             {
-            "attributeId": attributeId10,
-            "value": "Recliner"
+                "attributeId": attributeId10,
+                "value": "Recliner"
             },
             {
-            "attributeId": attributeId14,
-            "value": "New"
+                "attributeId": attributeId14,
+                "value": "New"
             }
         ],
         "quantity": 2
     },
 
+    // Table
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId14,
+        "attributes": [
+            {
+                "attributeId": attributeId10,
+                "value": "Coffee Table"
+            },
+            {
+                "attributeId": attributeId14,
+                "value": "New"
+            }
+        ],
+        "quantity": 3
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId14,
+        "attributes": [
+            {
+                "attributeId": attributeId10,
+                "value": "End Table"
+            },
+            {
+                "attributeId": attributeId14,
+                "value": "Used"
+            }
+        ],
+        "quantity": 2
+    },
+
+    // Chair
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId15,
+        "attributes": [
+            {
+                "attributeId": attributeId10,
+                "value": "Dining Chair"
+            },
+            {
+                "attributeId": attributeId14,
+                "value": "New"
+            }
+        ],
+        "quantity": 4
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId15,
+        "attributes": [
+            {
+                "attributeId": attributeId10,
+                "value": "Armchair"
+            },
+            {
+                "attributeId": attributeId14,
+                "value": "Used"
+            }
+        ],
+        "quantity": 1
+    },
 
 )

--- a/utils/dbTestData.script
+++ b/utils/dbTestData.script
@@ -1270,5 +1270,13 @@ db.inventoryItems.insertMany(
             }
         ],
         "quantity": 10
+    },
+
+    // Soap
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId9,
+        "attributes": [],
+        "quantity": 75
     }
 )

--- a/utils/dbTestData.script
+++ b/utils/dbTestData.script
@@ -2014,7 +2014,7 @@ db.inventoryItems.insertMany([
             {"attribute": attributeId15, "value": "QRST7890"}
         ],
         "quantity": 1,
-        "assignee": userid2
+        "assignee": userId2
     },
     {
         "_id": ObjectId(),

--- a/utils/dbTestData.script
+++ b/utils/dbTestData.script
@@ -1737,6 +1737,124 @@ db.inventoryItems.insertMany(
         "quantity": 1
     },
 
+    // Toaster
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId21,
+        "attributes": [
+            {
+                "attributeId": attributeId9,
+                "value": "Cuisinart"
+            },
+            {
+                "attributeId": attributeId10,
+                "value": "2 Slice"
+            },
+            {
+                "attributeId": attributeId14,
+                "value": "New"
+            }
+        ],
+        "quantity": 10
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId21,
+        "attributes": [
+            {
+                "attributeId": attributeId9,
+                "value": "KitchenAid"
+            },
+            {
+                "attributeId": attributeId10,
+                "value": "4 Slice"
+            },
+            {
+                "attributeId": attributeId14,
+                "value": "New"
+            }
+        ],
+        "quantity": 5
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId21,
+        "attributes": [
+            {
+                "attributeId": attributeId9,
+                "value": "Black & Decker"
+            },
+            {
+                "attributeId": attributeId10,
+                "value": "Toaster Oven"
+            },
+            {
+                "attributeId": attributeId14,
+                "value": "Used"
+            }
+        ],
+        "quantity": 2
+    },
 
+    // Blender
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId22,
+        "attributes": [
+            {
+                "attributeId": attributeId9,
+                "value": "Ninja"
+            },
+            {
+                "attributeId": attributeId10,
+                "value": "Countertop"
+            },
+            {
+                "attributeId": attributeId14,
+                "value": "New"
+            }
+        ],
+        "quantity": 8
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId22,
+        "attributes": [
+            {
+                "attributeId": attributeId9,
+                "value": "Vitamix"
+            },
+            {
+                "attributeId": attributeId10,
+                "value": "Personal"
+            },
+            {
+                "attributeId": attributeId14,
+                "value": "New"
+            }
+        ],
+        "quantity": 4
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId22,
+        "attributes": [
+            {
+                "attributeId": attributeId9,
+                "value": "Oster"
+            },
+            {
+                "attributeId": attributeId10,
+                "value": "Handheld"
+            },
+            {
+                "attributeId": attributeId14,
+                "value": "Used"
+            }
+        ],
+        "quantity": 1
+    },
+
+    
 
 )

--- a/utils/dbTestData.script
+++ b/utils/dbTestData.script
@@ -1891,7 +1891,7 @@ db.inventoryItems.insertMany([
             }
         ],
         "quantity": 1,
-        "assignee": "63fcb70862199670ed36177a"
+        "assignee": ObjectId("63fcb70862199670ed36177a")
     },
     {
         "_id": ObjectId(),
@@ -1902,7 +1902,7 @@ db.inventoryItems.insertMany([
             {"attribute": attributeId15, "value": "EFGH5678"}
         ],
         "quantity": 1,
-        "assignee": "63fa5c9265ada1f23e68b638"
+        "assignee": ObjectId("63fa5c9265ada1f23e68b638")
     },
     {
         "_id": ObjectId(),
@@ -1913,7 +1913,7 @@ db.inventoryItems.insertMany([
             {"attribute": attributeId15, "value": "IJKL9012"}
         ],
         "quantity": 1,
-        "assignee": "63f95a8a55d930aa6176f06b"
+        "assignee": ObjectId("63f95a8a55d930aa6176f06b")
     },
 
     //Keyboard
@@ -1926,7 +1926,7 @@ db.inventoryItems.insertMany([
             {"attribute": attributeId15, "value": "MNOP3456"}
         ],
         "quantity": 1,
-        "assignee": "63fcb70862199670ed36177a"
+        "assignee": ObjectId("63fcb70862199670ed36177a")
     },
     {
         "_id": ObjectId(),
@@ -1937,7 +1937,7 @@ db.inventoryItems.insertMany([
             {"attribute": attributeId15, "value": "QRST7890"}
         ],
         "quantity": 1,
-        "assignee": "63fa5c9265ada1f23e68b638"
+        "assignee": ObjectId("63fa5c9265ada1f23e68b638")
     },
     {
         "_id": ObjectId(),
@@ -1948,7 +1948,7 @@ db.inventoryItems.insertMany([
             {"attribute": attributeId15, "value": "UVWX1234"}
         ],
         "quantity": 1,
-        "assignee": "63f95a8a55d930aa6176f06b"
+        "assignee": ObjectId("63f95a8a55d930aa6176f06b")
     },
 
     // Mouse
@@ -1961,7 +1961,7 @@ db.inventoryItems.insertMany([
             {"attribute": attributeId15, "value": "ABCD1234"}
         ],
         "quantity": 1,
-        "assignee": "63fcb70862199670ed36177a"
+        "assignee": ObjectId("63fcb70862199670ed36177a")
     },
     {
         "_id": ObjectId(),
@@ -1972,7 +1972,7 @@ db.inventoryItems.insertMany([
             {"attribute": attributeId15, "value": "EFGH5678"}
         ],
         "quantity": 1,
-        "assignee": "63fa5c9265ada1f23e68b638"
+        "assignee": ObjectId("63fa5c9265ada1f23e68b638")
     },
     {
         "_id": ObjectId(),
@@ -1983,7 +1983,7 @@ db.inventoryItems.insertMany([
             {"attribute": attributeId15, "value": "IJKL9012"}
         ],
         "quantity": 1,
-        "assignee": "63f95a8a55d930aa6176f06b"
+        "assignee": ObjectId("63f95a8a55d930aa6176f06b")
     },
 
     // Monitor
@@ -1996,7 +1996,7 @@ db.inventoryItems.insertMany([
             {"attribute": attributeId15, "value": "MNOP3456"}
         ],
         "quantity": 1,
-        "assignee": "63fcb70862199670ed36177a"
+        "assignee": ObjectId("63fcb70862199670ed36177a")
     },
     {
         "_id": ObjectId(),
@@ -2007,7 +2007,7 @@ db.inventoryItems.insertMany([
             {"attribute": attributeId15, "value": "QRST7890"}
         ],
         "quantity": 1,
-        "assignee": "63fa5c9265ada1f23e68b638"
+        "assignee": ObjectId("63fa5c9265ada1f23e68b638")
     },
     {
         "_id": ObjectId(),
@@ -2018,7 +2018,7 @@ db.inventoryItems.insertMany([
             {"attribute": attributeId15, "value": "UVWX1234"}
         ],
         "quantity": 1,
-        "assignee": "63f95a8a55d930aa6176f06b"
+        "assignee": ObjectId("63f95a8a55d930aa6176f06b")
     },
 
 

--- a/utils/dbTestData.script
+++ b/utils/dbTestData.script
@@ -1401,4 +1401,38 @@ db.inventoryItems.insertMany(
     "attributes": [],
     "quantity": 50
     }, 
+
+    // FURNITURE
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId13,
+        "attributes": [
+            {
+            "attributeId": attributeId10,
+            "value": "Sectional"
+            },
+            {
+            "attributeId": attributeId14,
+            "value": "Used"
+            }
+        ],
+        "quantity": 3
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId13,
+        "attributes": [
+            {
+            "attributeId": attributeId10,
+            "value": "Recliner"
+            },
+            {
+            "attributeId": attributeId14,
+            "value": "New"
+            }
+        ],
+        "quantity": 2
+    },
+
+
 )

--- a/utils/dbTestData.script
+++ b/utils/dbTestData.script
@@ -1862,6 +1862,9 @@ db.inventoryItems.insertMany(
         "quantity": 1
     },
 
+
+    // ADMINISTRATIVE SUPPLIES
+
     //Laptop
     {
         "_id": ObjectId(),
@@ -1880,7 +1883,8 @@ db.inventoryItems.insertMany(
                 "value": "ABCD1234"
             }
         ],
-        "quantity": 1
+        "quantity": 1,
+        "assignee": "63fcb70862199670ed36177a"
     },
     {
         "_id": ObjectId(),
@@ -1890,7 +1894,8 @@ db.inventoryItems.insertMany(
             {"attribute": attributeId12, "value": 1200},
             {"attribute": attributeId15, "value": "EFGH5678"}
         ],
-        "quantity": 1
+        "quantity": 1,
+        "assignee": "63fa5c9265ada1f23e68b638"
     },
     {
         "_id": ObjectId(),
@@ -1900,7 +1905,8 @@ db.inventoryItems.insertMany(
             {"attribute": attributeId12, "value": 1800},
             {"attribute": attributeId15, "value": "IJKL9012"}
         ],
-        "quantity": 1
+        "quantity": 1,
+        "assignee": "63f95a8a55d930aa6176f06b"
     },
 
     //Keyboard
@@ -1912,7 +1918,8 @@ db.inventoryItems.insertMany(
             {"attribute": attributeId12, "value": 50},
             {"attribute": attributeId15, "value": "MNOP3456"}
         ],
-        "quantity": 1
+        "quantity": 1,
+        "assignee": "63fcb70862199670ed36177a"
     },
     {
         "_id": ObjectId(),
@@ -1922,7 +1929,8 @@ db.inventoryItems.insertMany(
             {"attribute": attributeId12, "value": 40},
             {"attribute": attributeId15, "value": "QRST7890"}
         ],
-        "quantity": 1
+        "quantity": 1,
+        "assignee": "63fa5c9265ada1f23e68b638"
     },
     {
         "_id": ObjectId(),
@@ -1932,7 +1940,8 @@ db.inventoryItems.insertMany(
             {"attribute": attributeId12, "value": 60},
             {"attribute": attributeId15, "value": "UVWX1234"}
         ],
-        "quantity": 1
+        "quantity": 1,
+        "assignee": "63f95a8a55d930aa6176f06b"
     },
 
     // Mouse
@@ -1944,7 +1953,8 @@ db.inventoryItems.insertMany(
             {"attribute": attributeId12, "value": 50},
             {"attribute": attributeId15, "value": "ABCD1234"}
         ],
-        "quantity": 1
+        "quantity": 1,
+        "assignee": "63fcb70862199670ed36177a"
     },
     {
         "_id": ObjectId(),
@@ -1954,7 +1964,8 @@ db.inventoryItems.insertMany(
             {"attribute": attributeId12, "value": 40},
             {"attribute": attributeId15, "value": "EFGH5678"}
         ],
-        "quantity": 1
+        "quantity": 1,
+        "assignee": "63fa5c9265ada1f23e68b638"
     },
     {
         "_id": ObjectId(),
@@ -1964,7 +1975,8 @@ db.inventoryItems.insertMany(
             {"attribute": attributeId12, "value": 60},
             {"attribute": attributeId15, "value": "IJKL9012"}
         ],
-        "quantity": 1
+        "quantity": 1,
+        "assignee": "63f95a8a55d930aa6176f06b"
     },
 
     // Monitor
@@ -1976,7 +1988,8 @@ db.inventoryItems.insertMany(
             {"attribute": attributeId12, "value": 1500},
             {"attribute": attributeId15, "value": "MNOP3456"}
         ],
-        "quantity": 1
+        "quantity": 1,
+        "assignee": "63fcb70862199670ed36177a"
     },
     {
         "_id": ObjectId(),
@@ -1986,7 +1999,8 @@ db.inventoryItems.insertMany(
             {"attribute": attributeId12, "value": 1200},
             {"attribute": attributeId15, "value": "QRST7890"}
         ],
-        "quantity": 1
+        "quantity": 1,
+        "assignee": "63fa5c9265ada1f23e68b638"
     },
     {
         "_id": ObjectId(),
@@ -1996,10 +2010,55 @@ db.inventoryItems.insertMany(
             {"attribute": attributeId12, "value": 1800},
             {"attribute": attributeId15, "value": "UVWX1234"}
         ],
-        "quantity": 1
+        "quantity": 1,
+        "assignee": "63f95a8a55d930aa6176f06b"
     },
 
-    
+
+    // NO CATEGORY
+
+    // Jumper Cables
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId27,
+        "attributes": [],
+        "quantity": 10
+    }
+
+    // Vacuum Cleaner
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId28,
+        "attributes": [
+            {
+                "attribute": attributeId9,
+                "value": "Dyson"
+            }
+        ],
+        "quantity": 2
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId28,
+        "attributes": [
+            {
+                "attribute": attributeId9,
+                "value": "Hoover"
+            }
+        ],
+        "quantity": 1
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId28,
+        "attributes": [
+            {
+                "attribute": attributeId9,
+                "value": "Shark"
+            }
+        ],
+        "quantity": 3
+    }
 
 
 

--- a/utils/dbTestData.script
+++ b/utils/dbTestData.script
@@ -1,4 +1,12 @@
-use test;
+use("test")
+
+// if specified, clear out all existing collections (except the users collection)
+if (true) {
+   db.attributes.deleteMany({}); 
+   db.categories.deleteMany({}); 
+   db.inventoryItems.deleteMany({}); 
+   db.itemDefinitions.deleteMany({}); 
+}
 
 // CATEGORIES
 const categoryId1 = ObjectId();
@@ -10,7 +18,7 @@ const categoryId6 = ObjectId();
 const categoryId7 = ObjectId();
 const categoryId8 = ObjectId();
 
-db.categories.insertMany(
+db.categories.insertMany([
     {
         "_id": categoryId1,
         "name": "Clothing"
@@ -38,12 +46,12 @@ db.categories.insertMany(
     {
         "_id": categoryId7,
         "name": "Linens"
-    }
+    },
     {
         "_id": categoryId8,
         "name": "Cleaning Supplies"
-    },
-);
+    }
+]);
 
 
 // ATTRIBUTES
@@ -64,7 +72,7 @@ const attributeId14 = ObjectId();
 const attributeId15 = ObjectId();
 const defaultColor = "#ebebeb";
 
-db.attributes.insertMany(
+db.attributes.insertMany([
     {
         "_id": attributeId1,
         "name": "Top Size",
@@ -155,7 +163,7 @@ db.attributes.insertMany(
         "possibleValues": ["New", "Used"],
         "color": defaultColor
     },
-);
+]);
 
 
 
@@ -170,6 +178,7 @@ const itemDefinitionId7 = ObjectId();
 const itemDefinitionId8 = ObjectId();
 const itemDefinitionId9 = ObjectId();
 const itemDefinitionId10 = ObjectId();
+const itemDefinitionId11 = ObjectId();
 const itemDefinitionId12 = ObjectId();
 const itemDefinitionId13 = ObjectId();
 const itemDefinitionId14 = ObjectId();
@@ -192,7 +201,7 @@ const itemDefinitionId30 = ObjectId();
 const itemDefinitionId31 = ObjectId();
 const itemDefinitionId32 = ObjectId();
 
-db.itemDefinitions.insertMany(
+db.itemDefinitions.insertMany([
     // clothing
     {
         "_id": itemDefinitionId1,
@@ -516,7 +525,7 @@ db.itemDefinitions.insertMany(
         "lowStockThreshold": 10,
         "criticalStockThreshold": 5
     }
-);
+]);
 
 
 
@@ -525,7 +534,7 @@ db.itemDefinitions.insertMany(
 
 
 // INVENTORY ITEMS
-db.inventoryItems.insertMany(
+db.inventoryItems.insertMany([
     // shirt
     {
         "_id": ObjectId(),
@@ -540,7 +549,7 @@ db.inventoryItems.insertMany(
                 "value": "Short-Sleeve"
             }
         ],
-        "quantity": 24,
+        "quantity": 24
     },
     {
         "_id": ObjectId(),
@@ -555,7 +564,7 @@ db.inventoryItems.insertMany(
                 "value": "Long-Sleeve"
             }
         ],
-        "quantity": 26,
+        "quantity": 26
     },
     {
         "_id": ObjectId(),
@@ -570,7 +579,7 @@ db.inventoryItems.insertMany(
                 "value": "Long-Sleeve"
             }
         ],
-        "quantity": 6,
+        "quantity": 6
     },
     {
         "_id": ObjectId(),
@@ -586,7 +595,7 @@ db.inventoryItems.insertMany(
             }
             
         ],
-        "quantity": 15,
+        "quantity": 15
     },
     {
         "_id": ObjectId(),
@@ -602,7 +611,7 @@ db.inventoryItems.insertMany(
             }
             
         ],
-        "quantity": 22,
+        "quantity": 22
     },
     {
         "_id": ObjectId(),
@@ -617,7 +626,7 @@ db.inventoryItems.insertMany(
                 "value": "Long-Sleeve"
             }
         ],
-        "quantity": 0,
+        "quantity": 0
     },
     {
         "_id": ObjectId(),
@@ -628,7 +637,7 @@ db.inventoryItems.insertMany(
                 "value": "Extra-Large"
             }, 
         ],
-        "quantity": 0,
+        "quantity": 0
     },
 
 
@@ -647,7 +656,7 @@ db.inventoryItems.insertMany(
                 "value": "28x30"
             }
         ],
-        "quantity": 16,
+        "quantity": 16
     },
     {
         "_id": ObjectId(),
@@ -662,7 +671,7 @@ db.inventoryItems.insertMany(
                 "value": "28x32"
             }
         ],
-        "quantity": 21,
+        "quantity": 21
     },
     {
         "_id": ObjectId(),
@@ -677,7 +686,7 @@ db.inventoryItems.insertMany(
                 "value": "Medium"
             }
         ],
-        "quantity": 3,
+        "quantity": 3
     },
     {
         "_id": ObjectId(),
@@ -692,7 +701,7 @@ db.inventoryItems.insertMany(
                 "value": "28x30"
             }
         ],
-        "quantity": 3,
+        "quantity": 3
     },
     {
         "_id": ObjectId(),
@@ -707,7 +716,7 @@ db.inventoryItems.insertMany(
                 "value": "Large"
             }
         ],
-        "quantity": 12,
+        "quantity": 12
     },
 
 
@@ -726,7 +735,7 @@ db.inventoryItems.insertMany(
                 "value": "Tennis Shoes"
             }
         ],
-        "quantity": 6,
+        "quantity": 6
     },
     {
         "_id": ObjectId(),
@@ -741,7 +750,7 @@ db.inventoryItems.insertMany(
                 "value": "Tennis Shoes"
             }
         ],
-        "quantity": 2,
+        "quantity": 2
     },
     {
         "_id": ObjectId(),
@@ -756,7 +765,7 @@ db.inventoryItems.insertMany(
                 "value": "Tennis Shoes"
             }
         ],
-        "quantity": 3,
+        "quantity": 3
     },
     {
         "_id": ObjectId(),
@@ -771,7 +780,7 @@ db.inventoryItems.insertMany(
                 "value": "Tennis Shoes"
             }
         ],
-        "quantity": 7,
+        "quantity": 7
     },
     {
         "_id": ObjectId(),
@@ -786,7 +795,7 @@ db.inventoryItems.insertMany(
                 "value": "Tennis Shoes"
             }
         ],
-        "quantity": 0,
+        "quantity": 0
     },
     {
         "_id": ObjectId(),
@@ -801,7 +810,7 @@ db.inventoryItems.insertMany(
                 "value": "Tennis Shoes"
             }
         ],
-        "quantity": 2,
+        "quantity": 2
     },
     {
         "_id": ObjectId(),
@@ -816,7 +825,7 @@ db.inventoryItems.insertMany(
                 "value": "Tennis Shoes"
             }
         ],
-        "quantity": 0,
+        "quantity": 0
     },
     {
         "_id": ObjectId(),
@@ -831,7 +840,7 @@ db.inventoryItems.insertMany(
                 "value": "Dress Shoes"
             }
         ],
-        "quantity": 6,
+        "quantity": 6
     },
     {
         "_id": ObjectId(),
@@ -846,7 +855,7 @@ db.inventoryItems.insertMany(
                 "value": "Dress Shoes"
             }
         ],
-        "quantity": 2,
+        "quantity": 2
     },
     {
         "_id": ObjectId(),
@@ -861,7 +870,7 @@ db.inventoryItems.insertMany(
                 "value": "Dress Shoes"
             }
         ],
-        "quantity": 3,
+        "quantity": 3
     },
     {
         "_id": ObjectId(),
@@ -876,7 +885,7 @@ db.inventoryItems.insertMany(
                 "value": "Dress Shoes"
             }
         ],
-        "quantity": 7,
+        "quantity": 7
     },
     {
         "_id": ObjectId(),
@@ -891,7 +900,7 @@ db.inventoryItems.insertMany(
                 "value": "Dress Shoes"
             }
         ],
-        "quantity": 0,
+        "quantity": 0
     },
     {
         "_id": ObjectId(),
@@ -906,7 +915,7 @@ db.inventoryItems.insertMany(
                 "value": "Dress Shoes"
             }
         ],
-        "quantity": 2,
+        "quantity": 2
     },
     {
         "_id": ObjectId(),
@@ -921,7 +930,7 @@ db.inventoryItems.insertMany(
                 "value": "Dress Shoes"
             }
         ],
-        "quantity": 0,
+        "quantity": 0
     },
     {
         "_id": ObjectId(),
@@ -936,7 +945,7 @@ db.inventoryItems.insertMany(
                 "value": "Boots"
             }
         ],
-        "quantity": 6,
+        "quantity": 6
     },
     {
         "_id": ObjectId(),
@@ -951,7 +960,7 @@ db.inventoryItems.insertMany(
                 "value": "Boots"
             }
         ],
-        "quantity": 2,
+        "quantity": 2
     },
     {
         "_id": ObjectId(),
@@ -966,7 +975,7 @@ db.inventoryItems.insertMany(
                 "value": "Boots"
             }
         ],
-        "quantity": 3,
+        "quantity": 3
     },
     {
         "_id": ObjectId(),
@@ -981,7 +990,7 @@ db.inventoryItems.insertMany(
                 "value": "Boots"
             }
         ],
-        "quantity": 7,
+        "quantity": 7
     },
     {
         "_id": ObjectId(),
@@ -996,7 +1005,7 @@ db.inventoryItems.insertMany(
                 "value": "Boots"
             }
         ],
-        "quantity": 0,
+        "quantity": 0
     },
     {
         "_id": ObjectId(),
@@ -1011,7 +1020,7 @@ db.inventoryItems.insertMany(
                 "value": "Boots"
             }
         ],
-        "quantity": 2,
+        "quantity": 2
     },
     {
         "_id": ObjectId(),
@@ -1026,7 +1035,7 @@ db.inventoryItems.insertMany(
                 "value": "Boots"
             }
         ],
-        "quantity": 0,
+        "quantity": 0
     },
 
     // bra
@@ -1403,10 +1412,10 @@ db.inventoryItems.insertMany(
 
     // Razor
     {
-    "_id": ObjectId(),
-    "itemDefinition": itemDefinitionId12,
-    "attributes": [],
-    "quantity": 50
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId12,
+        "attributes": [],
+        "quantity": 50
     }, 
 
     // FURNITURE
@@ -1696,8 +1705,7 @@ db.inventoryItems.insertMany(
             },
             {
                 "attributeId": attributeId11,
-                "value": "Single Ser
-            ve"},
+                "value": "Single Serve"},
             {
                 "attributeId": attributeId14,
                 "value": "New"
@@ -1730,8 +1738,7 @@ db.inventoryItems.insertMany(
         "attributes": [
             {
                 "attributeId": attributeId9,
-                "value": "Hamilton Bea
-            ch"},
+                "value": "Hamilton Beach"},
             {
                 "attributeId": attributeId11,
                 "value": "Percolator"
@@ -1876,7 +1883,7 @@ db.inventoryItems.insertMany(
             },
             {
                 "attribute": attributeId12,
-                "value": 
+                "value": 1300
             },
             {
                 "attribute": attributeId15,
@@ -2023,7 +2030,7 @@ db.inventoryItems.insertMany(
         "itemDefinition": itemDefinitionId27,
         "attributes": [],
         "quantity": 10
-    }
+    },
 
     // Vacuum Cleaner
     {
@@ -2140,4 +2147,4 @@ db.inventoryItems.insertMany(
         "attributes": [],
         "quantity": 2
     }
-)
+])

--- a/utils/dbTestData.script
+++ b/utils/dbTestData.script
@@ -1933,7 +1933,74 @@ db.inventoryItems.insertMany(
             {"attribute": attributeId15, "value": "UVWX1234"}
         ],
         "quantity": 1
-    }
+    },
+
+    // Mouse
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId25,
+        "attributes": [
+            {"attribute": attributeId9, "value": "Dell"},
+            {"attribute": attributeId12, "value": 50},
+            {"attribute": attributeId15, "value": "ABCD1234"}
+        ],
+        "quantity": 1
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId25,
+        "attributes": [
+            {"attribute": attributeId9, "value": "Lenovo"},
+            {"attribute": attributeId12, "value": 40},
+            {"attribute": attributeId15, "value": "EFGH5678"}
+        ],
+        "quantity": 1
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId25,
+        "attributes": [
+            {"attribute": attributeId9, "value": "HP"},
+            {"attribute": attributeId12, "value": 60},
+            {"attribute": attributeId15, "value": "IJKL9012"}
+        ],
+        "quantity": 1
+    },
+
+    // Monitor
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId26,
+        "attributes": [
+            {"attribute": attributeId9, "value": "Dell"},
+            {"attribute": attributeId12, "value": 1500},
+            {"attribute": attributeId15, "value": "MNOP3456"}
+        ],
+        "quantity": 1
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId26,
+        "attributes": [
+            {"attribute": attributeId9, "value": "Lenovo"},
+            {"attribute": attributeId12, "value": 1200},
+            {"attribute": attributeId15, "value": "QRST7890"}
+        ],
+        "quantity": 1
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId26,
+        "attributes": [
+            {"attribute": attributeId9, "value": "HP"},
+            {"attribute": attributeId12, "value": 1800},
+            {"attribute": attributeId15, "value": "UVWX1234"}
+        ],
+        "quantity": 1
+    },
+
+    
+
 
 
 )

--- a/utils/dbTestData.script
+++ b/utils/dbTestData.script
@@ -372,7 +372,7 @@ db.itemDefinitions.insertMany(
         "_id": itemDefinitionId19,
         "name": "Mini Fridge",
         "category": categoryId5,
-        "attributes": [attributeId9, attributeId11, attributeId14],
+        "attributes": [attributeId9, attributeId10, attributeId14],
         "internal": false,
         "lowStockThreshold": 0,
         "criticalStockThreshold": 0
@@ -381,7 +381,7 @@ db.itemDefinitions.insertMany(
         "_id": itemDefinitionId20,
         "name": "Coffee Maker",
         "category": categoryId5,
-        "attributes": [attributeId9, attributeId11, attributeId14],
+        "attributes": [attributeId9, attributeId10, attributeId14],
         "internal": false,
         "lowStockThreshold": 0,
         "criticalStockThreshold": 0
@@ -390,7 +390,7 @@ db.itemDefinitions.insertMany(
         "_id": itemDefinitionId21,
         "name": "Toaster",
         "category": categoryId5,
-        "attributes": [attributeId9, attributeId11, attributeId14],
+        "attributes": [attributeId9, attributeId10, attributeId14],
         "internal": false,
         "lowStockThreshold": 0,
         "criticalStockThreshold": 0
@@ -399,7 +399,7 @@ db.itemDefinitions.insertMany(
         "_id": itemDefinitionId22,
         "name": "Blender",
         "category": categoryId5,
-        "attributes": [attributeId9, attributeId11, attributeId14],
+        "attributes": [attributeId9, attributeId10, attributeId14],
         "internal": false,
         "lowStockThreshold": 0,
         "criticalStockThreshold": 0
@@ -1618,5 +1618,125 @@ db.inventoryItems.insertMany(
         ],
         "quantity": 2
     },
+
+    // Mini Fridge
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId19,
+        "attributes": [
+            {
+                "attributeId": attributeId9,
+                "value": "LG"
+            },
+            {
+                "attributeId": attributeId11,
+                "value": "Compact"
+            },
+            {
+                "attributeId": attributeId14,
+                "value": "New"
+            }
+        ],
+        "quantity": 10
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId19,
+        "attributes": [
+            {
+                "attributeId": attributeId9,
+                "value": "Samsung"
+            },
+            {
+                "attributeId": attributeId11,
+                "value": "Mini"
+            },
+            {
+                "attributeId": attributeId14,
+                "value": "New"
+            }
+        ],
+        "quantity": 5
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId19,
+        "attributes": [
+            {
+                "attributeId": attributeId9,
+                "value": "Whirlpool"
+            },
+            {
+                "attributeId": attributeId11,
+                "value": "Small"
+            },
+            {
+                "attributeId": attributeId14,
+                "value": "Used"
+            }
+        ],
+        "quantity": 2
+    },
+
+    // Coffee Maker
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId20,
+        "attributes": [
+            {
+                "attributeId": attributeId9,
+                "value": "Keurig"
+            },
+            {
+                "attributeId": attributeId11,
+                "value": "Single Ser
+            ve"},
+            {
+                "attributeId": attributeId14,
+                "value": "New"
+            }
+        ],
+        "quantity": 8
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId20,
+        "attributes": [
+            {
+                "attributeId": attributeId9,
+                "value": "Cuisinart"
+            },
+            {
+                "attributeId": attributeId11,
+                "value": "Drip"
+            },
+            {
+                "attributeId": attributeId14,
+                "value": "New"
+            }
+        ],
+        "quantity": 4
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId20,
+        "attributes": [
+            {
+                "attributeId": attributeId9,
+                "value": "Hamilton Bea
+            ch"},
+            {
+                "attributeId": attributeId11,
+                "value": "Percolator"
+            },
+            {
+                "attributeId": attributeId14,
+                "value": "Used"
+            }
+        ],
+        "quantity": 1
+    },
+
+
 
 )

--- a/utils/dbTestData.script
+++ b/utils/dbTestData.script
@@ -55,6 +55,9 @@ const attributeId8 = ObjectId();
 const attributeId9 = ObjectId();
 const attributeId10 = ObjectId();
 const attributeId11 = ObjectId();
+const attributeId12 = ObjectId();
+const attributeId13 = ObjectId();
+const attributeId14 = ObjectId();
 const defaultColor = "#ebebeb";
 
 db.attributes.insertMany(
@@ -77,57 +80,69 @@ db.attributes.insertMany(
         "color": defaultColor
     },
     {
-        "_id": attributeId10,
-        "name": "Pants Type",
-        "possibleValues": ["Khakis", "Pajamas", "Jeans"],
-        "color": defaultColor
-    },
-    {
-        "_id": attributeId11,
+        "_id": attributeId4,
         "name": "Pants Size",
         "possibleValues": "text",
         "color": defaultColor
     },
     {
-        "_id": attributeId4,
+        "_id": attributeId5,
         "name": "Shoe Size",
         "possibleValues": "number",
         "color": defaultColor
     },
     {
-        "_id": attributeId5,
+        "_id": attributeId6,
         "name": "Shoe Type",
         "possibleValues": "text",
         "color": defaultColor
     },
     {
-        "_id": attributeId11,
+        "_id": attributeId7,
         "name": "Bra Size",
         "possibleValues": "text",
         "color": defaultColor
     },
     {
-        "_id": attributeId6,
-        "name": "Weight",
+        "_id": attributeId8,
+        "name": "Toiletry Size",
         "possibleValues": "number",
         "color": defaultColor
     },
     {
-        "_id": attributeId7,
-        "name": "Oven Type",
-        "possibleValues": ["Electric", "Gas"],
-        "color": defaultColor
-    },
-    {
-        "_id": attributeId8,
+        "_id": attributeId9,
         "name": "Brand",
         "possibleValues": "text",
         "color": defaultColor
     },
     {
-        "_id": attributeId9,
+        "_id": attributeId10,
+        "name": "Type",
+        "possibleValues": "text",
+        "color": defaultColor
+    },
+    {
+        "_id": attributeId11,
+        "name": "Oven Type",
+        "possibleValues": ["Electric", "Gas"],
+        "color": defaultColor
+    },
+    {
+        "_id": attributeId12,
         "name": "Value",
         "possibleValues": "number",
+        "color": defaultColor
+    },
+    {
+        "_id": attributeId13,
+        "name": "Sheet Size",
+        "possibleValues": ["Twin", "Twin XL", "Full", "Queen", "King"],
+        "color": defaultColor
+    },
+    {
+        "_id": attributeId14,
+        "name": "Condition",
+        "possibleValues": ["New", "Used"],
         "color": defaultColor
     },
 );
@@ -188,6 +203,15 @@ db.itemDefinitions.insertMany(
     },
     {
         "_id": itemDefinitionId2,
+        "name": "Socks",
+        "category": categoryId1,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
         "name": "Oven",
         "category": categoryId1,
         "attributes": [attributeId1],
@@ -215,6 +239,15 @@ db.itemDefinitions.insertMany(
     },
     {
         "_id": itemDefinitionId2,
+        "name": "Dishwasher",
+        "category": categoryId1,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
         "name": "Coffee Maker",
         "category": categoryId1,
         "attributes": [attributeId1],
@@ -224,6 +257,24 @@ db.itemDefinitions.insertMany(
     },
     {
         "_id": itemDefinitionId2,
+        "name": "Toaster",
+        "category": categoryId1,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Blender",
+        "category": categoryId1,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
         "name": "Couch",
         "category": categoryId1,
         "attributes": [attributeId1],
@@ -234,6 +285,24 @@ db.itemDefinitions.insertMany(
     {
         "_id": itemDefinitionId2,
         "name": "Couch",
+        "category": categoryId4,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Table",
+        "category": categoryId4,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Chair",
         "category": categoryId4,
         "attributes": [attributeId1],
         "internal": false,
@@ -269,6 +338,33 @@ db.itemDefinitions.insertMany(
     },
     {
         "_id": itemDefinitionId2,
+        "name": "Monitor",
+        "category": categoryId4,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Jumper Cables",
+        "category": categoryId4,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Vacuum Cleaner",
+        "category": categoryId4,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
         "name": "Shampoo",
         "category": categoryId4,
         "attributes": [attributeId1],
@@ -296,7 +392,25 @@ db.itemDefinitions.insertMany(
     },
     {
         "_id": itemDefinitionId2,
+        "name": "Body Wash",
+        "category": categoryId4,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
         "name": "Shaving Cream",
+        "category": categoryId4,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Razor",
         "category": categoryId4,
         "attributes": [attributeId1],
         "internal": false,

--- a/utils/dbTestData.script
+++ b/utils/dbTestData.script
@@ -1140,5 +1140,79 @@ db.inventoryItems.insertMany(
         "itemDefinition": itemDefinitionId5,
         "attributes": [],
         "quantity": 20
-    }
+    },
+
+    // socks
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId6,
+        "attributes": [],
+        "quantity": 50
+    },
+
+
+
+
+
+
+
+
+    // Toiletries
+    // Shampoo
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId7,
+        "attributes": [
+            {
+                "attribute": attributeId8,
+                "value": "16 oz"
+            }
+        ],
+        "quantity": 20
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId7,
+        "attributes": [
+            {
+                "attribute": attributeId8,
+                "value": "32 oz"
+            }
+        ],
+        "quantity": 12
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId7,
+        "attributes": [
+            {
+                "attribute": attributeId8,
+                "value": "8 oz"
+            }
+        ],
+        "quantity": 5
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId7,
+        "attributes": [
+            {
+                "attribute": attributeId8,
+                "value": "12 oz"
+            }
+        ],
+        "quantity": 8
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId7,
+        "attributes": [
+            {
+                "attribute": attributeId8,
+                "value": "24 oz"
+            }
+        ],
+        "quantity": 10
+    },
+    
 )

--- a/utils/dbTestData.script
+++ b/utils/dbTestData.script
@@ -1,0 +1,355 @@
+use test;
+
+const categoryId1 = ObjectId();
+const categoryId2 = ObjectId();
+const categoryId3 = ObjectId();
+const categoryId4 = ObjectId();
+const categoryId5 = ObjectId();
+const categoryId6 = ObjectId();
+const categoryId7 = ObjectId();
+
+db.categories.insertMany(
+    {
+        "_id": categoryId1,
+        "name": "Clothing"
+    },
+    {
+        "_id": categoryId2,
+        "name": "Toiletries"
+    },
+    {
+        "_id": categoryId3,
+        "name": "Furniture"
+    },
+    {
+        "_id": categoryId4,
+        "name": "Large Appliances"
+    },
+    {
+        "_id": categoryId5,
+        "name": "Small Appliances"
+    },
+    {
+        "_id": categoryId6,
+        "name": "Administrative Supplies"
+    },
+    {
+        "_id": categoryId7,
+        "name": "Cleaning Supplies"
+    },
+    {
+        "_id": categoryId7,
+        "name": "Linens"
+    }
+);
+
+
+const attributeId1 = ObjectId();
+const attributeId2 = ObjectId();
+const attributeId3 = ObjectId();
+const attributeId4 = ObjectId();
+const attributeId5 = ObjectId();
+const attributeId6 = ObjectId();
+const attributeId7 = ObjectId();
+const attributeId8 = ObjectId();
+const attributeId9 = ObjectId();
+const attributeId10 = ObjectId();
+const attributeId11 = ObjectId();
+const defaultColor = "#ebebeb";
+
+db.attributes.insertMany(
+    {
+        "_id": attributeId1,
+        "name": "Top Size",
+        "possibleValues": ["Small", "Medium", "Large", "Extra-Large"],
+        "color": defaultColor
+    },
+    {
+        "_id": attributeId2,
+        "name": "Shirt Type",
+        "possibleValues": ["Short-Sleeve", "Long-Sleeve"],
+        "color": defaultColor
+    },
+    {
+        "_id": attributeId3,
+        "name": "Pants Length",
+        "possibleValues": ["Shorts", "Long Pants"],
+        "color": defaultColor
+    },
+    {
+        "_id": attributeId10,
+        "name": "Pants Type",
+        "possibleValues": ["Khakis", "Pajamas", "Jeans"],
+        "color": defaultColor
+    },
+    {
+        "_id": attributeId11,
+        "name": "Pants Size",
+        "possibleValues": "text",
+        "color": defaultColor
+    },
+    {
+        "_id": attributeId4,
+        "name": "Shoe Size",
+        "possibleValues": "number",
+        "color": defaultColor
+    },
+    {
+        "_id": attributeId5,
+        "name": "Shoe Type",
+        "possibleValues": "text",
+        "color": defaultColor
+    },
+    {
+        "_id": attributeId11,
+        "name": "Bra Size",
+        "possibleValues": "text",
+        "color": defaultColor
+    },
+    {
+        "_id": attributeId6,
+        "name": "Weight",
+        "possibleValues": "number",
+        "color": defaultColor
+    },
+    {
+        "_id": attributeId7,
+        "name": "Oven Type",
+        "possibleValues": ["Electric", "Gas"],
+        "color": defaultColor
+    },
+    {
+        "_id": attributeId8,
+        "name": "Brand",
+        "possibleValues": "text",
+        "color": defaultColor
+    },
+    {
+        "_id": attributeId9,
+        "name": "Value",
+        "possibleValues": "number",
+        "color": defaultColor
+    },
+);
+
+
+const itemDefinitionId1 = ObjectId();
+const itemDefinitionId2 = ObjectId();
+const itemDefinitionId3 = ObjectId();
+const itemDefinitionId4 = ObjectId();
+const itemDefinitionId5 = ObjectId();
+const itemDefinitionId6 = ObjectId();
+
+db.itemDefinitions.insertMany(
+    {
+        "_id": itemDefinitionId1,
+        "name": "Shirt",
+        "category": categoryId1,
+        "attributes": [attributeId1, attributeId2],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Pants",
+        "category": categoryId1,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Shoes",
+        "category": categoryId1,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Bra",
+        "category": categoryId1,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Underwear",
+        "category": categoryId1,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Oven",
+        "category": categoryId1,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Mini Fridge",
+        "category": categoryId1,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Refrigerator",
+        "category": categoryId1,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Coffee Maker",
+        "category": categoryId1,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Couch",
+        "category": categoryId1,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Couch",
+        "category": categoryId4,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Laptop",
+        "category": categoryId4,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Keyboard",
+        "category": categoryId4,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Mouse",
+        "category": categoryId4,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Shampoo",
+        "category": categoryId4,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Conditioner",
+        "category": categoryId4,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Soap",
+        "category": categoryId4,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Shaving Cream",
+        "category": categoryId4,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Towel",
+        "category": categoryId4,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Bedsheet",
+        "category": categoryId4,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Blanket",
+        "category": categoryId4,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    },
+    {
+        "_id": itemDefinitionId2,
+        "name": "Pillow",
+        "category": categoryId4,
+        "attributes": [attributeId1],
+        "internal": false,
+        "lowStockThreshold": 20,
+        "criticalStockThreshold": 10
+    }
+);
+
+db.inventoryItems.insertMany(
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId1,
+        "attributes": {
+            "attribute": attributeId1,
+            "value": "seven"
+        },
+        "quantity": 10,
+        "asignee": ObjectId()
+    }
+)

--- a/utils/dbTestData.script
+++ b/utils/dbTestData.script
@@ -1,5 +1,6 @@
 use test;
 
+// CATEGORIES
 const categoryId1 = ObjectId();
 const categoryId2 = ObjectId();
 const categoryId3 = ObjectId();
@@ -45,6 +46,7 @@ db.categories.insertMany(
 );
 
 
+// ATTRIBUTES
 const attributeId1 = ObjectId();
 const attributeId2 = ObjectId();
 const attributeId3 = ObjectId();
@@ -149,6 +151,8 @@ db.attributes.insertMany(
 );
 
 
+
+// ITEM DEFINITIONS
 const itemDefinitionId1 = ObjectId();
 const itemDefinitionId2 = ObjectId();
 const itemDefinitionId3 = ObjectId();
@@ -182,6 +186,7 @@ const itemDefinitionId31 = ObjectId();
 const itemDefinitionId32 = ObjectId();
 
 db.itemDefinitions.insertMany(
+    // clothing
     {
         "_id": itemDefinitionId1,
         "name": "Shirt",
@@ -239,7 +244,7 @@ db.itemDefinitions.insertMany(
 
 
 
-
+    // toiletries
     {
         "_id": itemDefinitionId7,
         "name": "Shampoo",
@@ -298,6 +303,7 @@ db.itemDefinitions.insertMany(
 
 
 
+    // furniture
     {
         "_id": itemDefinitionId13,
         "name": "Couch",
@@ -328,7 +334,7 @@ db.itemDefinitions.insertMany(
 
 
 
-
+    // large appliances
     {
         "_id": itemDefinitionId16,
         "name": "Oven",
@@ -361,7 +367,7 @@ db.itemDefinitions.insertMany(
 
 
 
-
+    // small appliances
     {
         "_id": itemDefinitionId19,
         "name": "Mini Fridge",
@@ -403,7 +409,7 @@ db.itemDefinitions.insertMany(
 
 
 
-
+    // administrative supplies
     {
         "_id": itemDefinitionId23,
         "name": "Laptop",
@@ -446,7 +452,7 @@ db.itemDefinitions.insertMany(
 
 
 
-
+    // no category
     {
         "_id": itemDefinitionId27,
         "name": "Jumper Cables",
@@ -466,7 +472,7 @@ db.itemDefinitions.insertMany(
     
 
 
-
+    // linens
     {
         "_id": itemDefinitionId29,
         "name": "Towel",
@@ -510,15 +516,621 @@ db.itemDefinitions.insertMany(
 
 
 
+
+// INVENTORY ITEMS
 db.inventoryItems.insertMany(
+    // shirt
     {
         "_id": ObjectId(),
         "itemDefinition": itemDefinitionId1,
-        "attributes": {
-            "attribute": attributeId1,
-            "value": "seven"
-        },
-        "quantity": 10,
-        "asignee": ObjectId()
+        "attributes": [
+            {
+                "attribute": attributeId1,
+                "value": "Small"
+            }, 
+            {
+                "attribute": attributeId2,
+                "value": "Short-Sleeve"
+            }
+        ],
+        "quantity": 24,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId1,
+        "attributes": [
+            {
+                "attribute": attributeId1,
+                "value": "Small"
+            }, 
+            {
+                "attribute": attributeId2,
+                "value": "Long-Sleeve"
+            }
+        ],
+        "quantity": 26,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId1,
+        "attributes": [
+            {
+                "attribute": attributeId1,
+                "value": "Medium"
+            }, 
+            {
+                "attribute": attributeId2,
+                "value": "Long-Sleeve"
+            }
+        ],
+        "quantity": 6,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId1,
+        "attributes": [
+            {
+                "attribute": attributeId1,
+                "value": "Large"
+            },
+            {
+                "attribute": attributeId2,
+                "value": "Long-Sleeve"
+            }
+            
+        ],
+        "quantity": 15,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId1,
+        "attributes": [
+            {
+                "attribute": attributeId1,
+                "value": "Large"
+            },
+            {
+                "attribute": attributeId2,
+                "value": "Short-Sleeve"
+            }
+            
+        ],
+        "quantity": 22,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId1,
+        "attributes": [
+            {
+                "attribute": attributeId1,
+                "value": "Extra-Large"
+            }, 
+            {
+                "attribute": attributeId2,
+                "value": "Long-Sleeve"
+            }
+        ],
+        "quantity": 0,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId1,
+        "attributes": [
+            {
+                "attribute": attributeId1,
+                "value": "Extra-Large"
+            }, 
+        ],
+        "quantity": 0,
+    },
+
+
+
+    // pants
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId2,
+        "attributes": [
+            {
+                "attribute": attributeId3,
+                "value": "Shorts"
+            }, 
+            {
+                "attribute": attributeId4,
+                "value": "28x30"
+            }
+        ],
+        "quantity": 16,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId2,
+        "attributes": [
+            {
+                "attribute": attributeId3,
+                "value": "Shorts"
+            }, 
+            {
+                "attribute": attributeId4,
+                "value": "28x32"
+            }
+        ],
+        "quantity": 21,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId2,
+        "attributes": [
+            {
+                "attribute": attributeId3,
+                "value": "Long Pants"
+            }, 
+            {
+                "attribute": attributeId4,
+                "value": "Medium"
+            }
+        ],
+        "quantity": 3,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId2,
+        "attributes": [
+            {
+                "attribute": attributeId3,
+                "value": "Long Pants"
+            }, 
+            {
+                "attribute": attributeId4,
+                "value": "28x30"
+            }
+        ],
+        "quantity": 3,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId2,
+        "attributes": [
+            {
+                "attribute": attributeId3,
+                "value": "Long Pants"
+            }, 
+            {
+                "attribute": attributeId4,
+                "value": "Large"
+            }
+        ],
+        "quantity": 12,
+    },
+
+
+
+    // shoes
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId3,
+        "attributes": [
+            {
+                "attribute": attributeId5,
+                "value": "12"
+            }, 
+            {
+                "attribute": attributeId6,
+                "value": "Tennis Shoes"
+            }
+        ],
+        "quantity": 6,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId3,
+        "attributes": [
+            {
+                "attribute": attributeId5,
+                "value": "4"
+            }, 
+            {
+                "attribute": attributeId6,
+                "value": "Tennis Shoes"
+            }
+        ],
+        "quantity": 2,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId3,
+        "attributes": [
+            {
+                "attribute": attributeId5,
+                "value": "7"
+            }, 
+            {
+                "attribute": attributeId6,
+                "value": "Tennis Shoes"
+            }
+        ],
+        "quantity": 3,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId3,
+        "attributes": [
+            {
+                "attribute": attributeId5,
+                "value": "8"
+            }, 
+            {
+                "attribute": attributeId6,
+                "value": "Tennis Shoes"
+            }
+        ],
+        "quantity": 7,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId3,
+        "attributes": [
+            {
+                "attribute": attributeId5,
+                "value": "11"
+            }, 
+            {
+                "attribute": attributeId6,
+                "value": "Tennis Shoes"
+            }
+        ],
+        "quantity": 0,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId3,
+        "attributes": [
+            {
+                "attribute": attributeId5,
+                "value": "12.5"
+            }, 
+            {
+                "attribute": attributeId6,
+                "value": "Tennis Shoes"
+            }
+        ],
+        "quantity": 2,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId3,
+        "attributes": [
+            {
+                "attribute": attributeId5,
+                "value": "11.5"
+            }, 
+            {
+                "attribute": attributeId6,
+                "value": "Tennis Shoes"
+            }
+        ],
+        "quantity": 0,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId3,
+        "attributes": [
+            {
+                "attribute": attributeId5,
+                "value": "12"
+            }, 
+            {
+                "attribute": attributeId6,
+                "value": "Dress Shoes"
+            }
+        ],
+        "quantity": 6,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId3,
+        "attributes": [
+            {
+                "attribute": attributeId5,
+                "value": "4"
+            }, 
+            {
+                "attribute": attributeId6,
+                "value": "Dress Shoes"
+            }
+        ],
+        "quantity": 2,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId3,
+        "attributes": [
+            {
+                "attribute": attributeId5,
+                "value": "7"
+            }, 
+            {
+                "attribute": attributeId6,
+                "value": "Dress Shoes"
+            }
+        ],
+        "quantity": 3,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId3,
+        "attributes": [
+            {
+                "attribute": attributeId5,
+                "value": "8"
+            }, 
+            {
+                "attribute": attributeId6,
+                "value": "Dress Shoes"
+            }
+        ],
+        "quantity": 7,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId3,
+        "attributes": [
+            {
+                "attribute": attributeId5,
+                "value": "11"
+            }, 
+            {
+                "attribute": attributeId6,
+                "value": "Dress Shoes"
+            }
+        ],
+        "quantity": 0,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId3,
+        "attributes": [
+            {
+                "attribute": attributeId5,
+                "value": "12.5"
+            }, 
+            {
+                "attribute": attributeId6,
+                "value": "Dress Shoes"
+            }
+        ],
+        "quantity": 2,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId3,
+        "attributes": [
+            {
+                "attribute": attributeId5,
+                "value": "11.5"
+            }, 
+            {
+                "attribute": attributeId6,
+                "value": "Dress Shoes"
+            }
+        ],
+        "quantity": 0,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId3,
+        "attributes": [
+            {
+                "attribute": attributeId5,
+                "value": "12"
+            }, 
+            {
+                "attribute": attributeId6,
+                "value": "Boots"
+            }
+        ],
+        "quantity": 6,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId3,
+        "attributes": [
+            {
+                "attribute": attributeId5,
+                "value": "4"
+            }, 
+            {
+                "attribute": attributeId6,
+                "value": "Boots"
+            }
+        ],
+        "quantity": 2,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId3,
+        "attributes": [
+            {
+                "attribute": attributeId5,
+                "value": "7"
+            }, 
+            {
+                "attribute": attributeId6,
+                "value": "Boots"
+            }
+        ],
+        "quantity": 3,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId3,
+        "attributes": [
+            {
+                "attribute": attributeId5,
+                "value": "8"
+            }, 
+            {
+                "attribute": attributeId6,
+                "value": "Boots"
+            }
+        ],
+        "quantity": 7,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId3,
+        "attributes": [
+            {
+                "attribute": attributeId5,
+                "value": "11"
+            }, 
+            {
+                "attribute": attributeId6,
+                "value": "Boots"
+            }
+        ],
+        "quantity": 0,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId3,
+        "attributes": [
+            {
+                "attribute": attributeId5,
+                "value": "12.5"
+            }, 
+            {
+                "attribute": attributeId6,
+                "value": "Boots"
+            }
+        ],
+        "quantity": 2,
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId3,
+        "attributes": [
+            {
+                "attribute": attributeId5,
+                "value": "11.5"
+            }, 
+            {
+                "attribute": attributeId6,
+                "value": "Boots"
+            }
+        ],
+        "quantity": 0,
+    },
+
+    // bra
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId4,
+        "attributes": [
+            {
+                "attribute": attributeId7,
+                "value": "30A"
+            }
+        ],
+        "quantity": 3
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId4,
+        "attributes": [
+            {
+                "attribute": attributeId7,
+                "value": "32B"
+            }
+        ],
+        "quantity": 10
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId4,
+        "attributes": [
+            {
+                "attribute": attributeId7,
+                "value": "34C"
+            }
+        ],
+        "quantity": 7
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId4,
+        "attributes": [
+            {
+                "attribute": attributeId7,
+                "value": "36D"
+            }
+        ],
+        "quantity": 2
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId4,
+        "attributes": [
+            {
+                "attribute": attributeId7,
+                "value": "38DD"
+            }
+        ],
+        "quantity": 0
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId4,
+        "attributes": [
+            {
+                "attribute": attributeId7,
+                "value": "40C"
+            }
+        ],
+        "quantity": 6
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId4,
+        "attributes": [
+            {
+                "attribute": attributeId7,
+                "value": "42B"
+            }
+        ],
+        "quantity": 4
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId4,
+        "attributes": [
+            {
+                "attribute": attributeId7,
+                "value": "44A"
+            }
+        ],
+        "quantity": 0
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId4,
+        "attributes": [
+            {
+                "attribute": attributeId7,
+                "value": "46D"
+            }
+        ],
+        "quantity": 8
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId4,
+        "attributes": [
+            {
+                "attribute": attributeId7,
+                "value": "48DD"
+            }
+        ],
+        "quantity": 1
     }
 )

--- a/utils/dbTestData.script
+++ b/utils/dbTestData.script
@@ -1214,5 +1214,61 @@ db.inventoryItems.insertMany(
         ],
         "quantity": 10
     },
-    
+
+    // conditioner
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId8,
+        "attributes": [
+            {
+                "attribute": attributeId8,
+                "value": "16 oz"
+            }
+        ],
+        "quantity": 20
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId8,
+        "attributes": [
+            {
+                "attribute": attributeId8,
+                "value": "32 oz"
+            }
+        ],
+        "quantity": 12
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId8,
+        "attributes": [
+            {
+                "attribute": attributeId8,
+                "value": "8 oz"
+            }
+        ],
+        "quantity": 5
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId8,
+        "attributes": [
+            {
+                "attribute": attributeId8,
+                "value": "12 oz"
+            }
+        ],
+        "quantity": 8
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId8,
+        "attributes": [
+            {
+                "attribute": attributeId8,
+                "value": "24 oz"
+            }
+        ],
+        "quantity": 10
+    }
 )

--- a/utils/dbTestData.script
+++ b/utils/dbTestData.script
@@ -61,6 +61,7 @@ const attributeId11 = ObjectId();
 const attributeId12 = ObjectId();
 const attributeId13 = ObjectId();
 const attributeId14 = ObjectId();
+const attributeId15 = ObjectId();
 const defaultColor = "#ebebeb";
 
 db.attributes.insertMany(
@@ -128,6 +129,12 @@ db.attributes.insertMany(
         "_id": attributeId11,
         "name": "Oven Type",
         "possibleValues": ["Electric", "Gas"],
+        "color": defaultColor
+    },
+    {
+        "_id": attributeId15,
+        "name": "Serial Number",
+        "possibleValues": "text",
         "color": defaultColor
     },
     {
@@ -414,7 +421,7 @@ db.itemDefinitions.insertMany(
         "_id": itemDefinitionId23,
         "name": "Laptop",
         "category": categoryId6,
-        "attributes": [attributeId9, attributeId12],
+        "attributes": [attributeId9, attributeId12, attributeId15],
         "internal": true,
         "lowStockThreshold": 0,
         "criticalStockThreshold": 0
@@ -423,7 +430,7 @@ db.itemDefinitions.insertMany(
         "_id": itemDefinitionId24,
         "name": "Keyboard",
         "category": categoryId6,
-        "attributes": [attributeId9, attributeId12],
+        "attributes": [attributeId9, attributeId12, attributeId15],
         "internal": true,
         "lowStockThreshold": 0,
         "criticalStockThreshold": 0
@@ -432,7 +439,7 @@ db.itemDefinitions.insertMany(
         "_id": itemDefinitionId25,
         "name": "Mouse",
         "category": categoryId6,
-        "attributes": [attributeId9, attributeId12],
+        "attributes": [attributeId9, attributeId12, attributeId15],
         "internal": true,
         "lowStockThreshold": 0,
         "criticalStockThreshold": 0
@@ -441,7 +448,7 @@ db.itemDefinitions.insertMany(
         "_id": itemDefinitionId26,
         "name": "Monitor",
         "category": categoryId6,
-        "attributes": [attributeId9, attributeId12],
+        "attributes": [attributeId9, attributeId12, attributeId15],
         "internal": true,
         "lowStockThreshold": 0,
         "criticalStockThreshold": 0
@@ -1855,6 +1862,78 @@ db.inventoryItems.insertMany(
         "quantity": 1
     },
 
-    
+    //Laptop
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId23,
+        "attributes": [
+            {
+                "attribute": attributeId9,
+                "value": "Dell"
+            },
+            {
+                "attribute": attributeId12,
+                "value": 
+            },
+            {
+                "attribute": attributeId15,
+                "value": "ABCD1234"
+            }
+        ],
+        "quantity": 1
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId23,
+        "attributes": [
+            {"attribute": attributeId9, "value": "Lenovo"},
+            {"attribute": attributeId12, "value": 1200},
+            {"attribute": attributeId15, "value": "EFGH5678"}
+        ],
+        "quantity": 1
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId23,
+        "attributes": [
+            {"attribute": attributeId9, "value": "HP"},
+            {"attribute": attributeId12, "value": 1800},
+            {"attribute": attributeId15, "value": "IJKL9012"}
+        ],
+        "quantity": 1
+    },
+
+    //Keyboard
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId24,
+        "attributes": [
+            {"attribute": attributeId9, "value": "Dell"},
+            {"attribute": attributeId12, "value": 50},
+            {"attribute": attributeId15, "value": "MNOP3456"}
+        ],
+        "quantity": 1
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId24,
+        "attributes": [
+            {"attribute": attributeId9, "value": "Lenovo"},
+            {"attribute": attributeId12, "value": 40},
+            {"attribute": attributeId15, "value": "QRST7890"}
+        ],
+        "quantity": 1
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId24,
+        "attributes": [
+            {"attribute": attributeId9, "value": "HP"},
+            {"attribute": attributeId12, "value": 60},
+            {"attribute": attributeId15, "value": "UVWX1234"}
+        ],
+        "quantity": 1
+    }
+
 
 )

--- a/utils/dbTestData.script
+++ b/utils/dbTestData.script
@@ -2058,8 +2058,86 @@ db.inventoryItems.insertMany(
             }
         ],
         "quantity": 3
+    },
+
+    // Towel
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId29,
+        "attributes": [],
+        "quantity": 1
+    },
+
+    // Bedsheet
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId30,
+        "attributes": [
+            {
+                "attribute": attributeId13,
+                "value": "Twin"
+            }
+        ],
+        "quantity": 3
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId30,
+        "attributes": [
+            {
+                "attribute": attributeId13,
+                "value": "Twin XL"
+            }
+        ],
+        "quantity": 7
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId30,
+        "attributes": [
+            {
+                "attribute": attributeId13,
+                "value": "Full"
+            }
+        ],
+        "quantity": 2
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId30,
+        "attributes": [
+            {
+            "attribute": attributeId13,
+            "value": "Queen"
+            }
+        ],
+        "quantity": 0
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId30,
+        "attributes": [
+            {
+                "attribute": attributeId13,
+                "value": "King"
+            }
+        ],
+        "quantity": 1
+    },
+
+    // Blanket
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId31,
+        "attributes": [],
+        "quantity": 15
+    },
+
+    // Pillow
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId32,
+        "attributes": [],
+        "quantity": 2
     }
-
-
-
 )

--- a/utils/dbTestData.script
+++ b/utils/dbTestData.script
@@ -1132,5 +1132,13 @@ db.inventoryItems.insertMany(
             }
         ],
         "quantity": 1
+    },
+
+    // Underwear
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId5,
+        "attributes": [],
+        "quantity": 20
     }
 )

--- a/utils/dbTestData.script
+++ b/utils/dbTestData.script
@@ -1278,5 +1278,61 @@ db.inventoryItems.insertMany(
         "itemDefinition": itemDefinitionId9,
         "attributes": [],
         "quantity": 75
+    },
+
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId10,
+        "attributes": [
+            {
+                "attribute": attributeId8,
+                "value": "16 oz"
+            }
+        ],
+        "quantity": 20
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId10,
+        "attributes": [
+            {
+                "attribute": attributeId8,
+                "value": "32 oz"
+            }
+        ],
+        "quantity": 12
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId10,
+        "attributes": [
+            {
+                "attribute": attributeId8,
+                "value": "8 oz"
+            }
+        ],
+        "quantity": 5
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId10,
+        "attributes": [
+            {
+                "attribute": attributeId8,
+                "value": "12 oz"
+            }
+        ],
+        "quantity": 8
+    },
+    {
+        "_id": ObjectId(),
+        "itemDefinition": itemDefinitionId10,
+        "attributes": [
+            {
+                "attribute": attributeId8,
+                "value": "24 oz"
+            }
+        ],
+        "quantity": 10
     }
 )

--- a/utils/dbTestData.script
+++ b/utils/dbTestData.script
@@ -1391,5 +1391,14 @@ db.inventoryItems.insertMany(
             }
         ],
         "quantity": 8
-    }
+    },
+
+
+    // Razor
+    {
+    "_id": ObjectId(),
+    "itemDefinition": itemDefinitionId12,
+    "attributes": [],
+    "quantity": 50
+    }, 
 )


### PR DESCRIPTION
Clears out and then populates the database with LOTS of test data. If you don't want to clear out the database, and only add to it, set the conditional on line 4 to false.

Edge cases I considered:

- ItemDefinitions without a category (ID 27 & 28)
- Category without ItemDefinitions (ID 8)
- ItemDefinitions without attributes (several)
- InventoryItems without all possible attributes (Several, all in categoryId 1 I believe). 
- 0 quantity
- low/critically low quantity
- internal items with assignees on the inventoryItem
- Different color attributes

If there are any more considerations, let me know.
You don't have to pour over every line, but at least visit every section and make sure that the format/objects are correct. I've ran this, so it's all in the database and works, but none of it was validated.

To run the script, follow the instructions on our Confluence page, which can be found [here](https://team-16679321250140.atlassian.net/jira/software/projects/CCAHT/pages)

