### PR TITLE
Ccaht 56 hook up inventory page and inventory item list component 2

### DIFF
--- a/pages/api/attributes/[attributeId].ts
+++ b/pages/api/attributes/[attributeId].ts
@@ -12,7 +12,7 @@ import constants from 'utils/constants'
 // @route GET api/attributes/[attributeId] - Returns a single Attribute object given by a attributeId - Private
 // @route PUT api/attributes/[attributeId] - Updates an existing Attribute object (identified by attributeId) with a new Attribute object - Private
 // @route DELETE api/attributes/[attributeId] - Deletes a single Atttribute object (identified by attributeId) - Private
-export default async function handler(
+export default async function attributeHandler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {

--- a/pages/api/attributes/index.ts
+++ b/pages/api/attributes/index.ts
@@ -8,7 +8,7 @@ import constants from 'utils/constants'
 
 // @route GET api/attributes - Returns a list of all Attributes in the database - Private
 // @route POST api/attributes - Create an Attribute from request body - Private
-export default async function handler(
+export default async function attributesHandler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {

--- a/pages/api/categories/[categoryId].ts
+++ b/pages/api/categories/[categoryId].ts
@@ -12,7 +12,7 @@ import constants from 'utils/constants'
 // @route GET api/categories/[categoryId] - Returns a single Category object given a categoryId - Private
 // @route PUT api/users/[categoryId] - Updates an existing Category object (identified by categoryId) with a new Category object - Private
 // @route DELETE api/users/[categoryId] - Deletes a single Category object (identified by categoryId) - Private
-export default async function handler(
+export default async function categoryHandler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {

--- a/pages/api/categories/index.ts
+++ b/pages/api/categories/index.ts
@@ -8,7 +8,7 @@ import constants from 'utils/constants'
 
 // @route GET api/categories - Returns a list of all Categories in the database - Private
 // @route POST /api/categories - Create a category from request body - Private
-export default async function handler(
+export default async function categoriesHandler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {

--- a/pages/api/inventoryItems/[inventoryItemId].ts
+++ b/pages/api/inventoryItems/[inventoryItemId].ts
@@ -12,7 +12,7 @@ import InventoryItemSchema from 'server/models/InventoryItem'
 // @route GET api/itemDefintions/[inventoryItemId] - Returns a single InventoryItem object given a inventoryItemId - Private
 // @route PUT api/users/[inventoryItemId] - Updates an existing InventoryItem object (identified by inventoryItemId) with a new InventoryItem object - Private
 // @route DELETE api/users/[inventoryItemId] - Deletes a single InventoryItem object (identified by inventoryItemId) - Private
-export default async function handler(
+export default async function inventoryItemHandler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {

--- a/pages/api/inventoryItems/[inventoryItemId].ts
+++ b/pages/api/inventoryItems/[inventoryItemId].ts
@@ -1,0 +1,69 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { getInventoryItem } from 'server/actions/InventoryItems'
+import { ApiError, InventoryItemPutRequest } from 'utils/types'
+import { serverAuth } from 'utils/auth'
+import {
+  apiInventoryItemValidation,
+  apiObjectIdValidation,
+} from 'utils/apiValidators'
+import * as MongoDriver from 'server/actions/MongoDriver'
+import InventoryItemSchema from 'server/models/InventoryItem'
+
+// @route GET api/itemDefintions/[inventoryItemId] - Returns a single InventoryItem object given a inventoryItemId - Private
+// @route PUT api/users/[inventoryItemId] - Updates an existing InventoryItem object (identified by inventoryItemId) with a new InventoryItem object - Private
+// @route DELETE api/users/[inventoryItemId] - Deletes a single InventoryItem object (identified by inventoryItemId) - Private
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  try {
+    // ensure user is logged in
+    await serverAuth(req, res)
+
+    apiObjectIdValidation(req?.query?.inventoryItemId as string)
+    const inventoryItemId = req.query.inventoryItemId as string
+    switch (req.method) {
+      case 'GET': {
+        const inventoryItem = await getInventoryItem(inventoryItemId)
+
+        return res.status(200).json({
+          success: true,
+          payload: inventoryItem,
+        })
+      }
+      case 'PUT': {
+        apiInventoryItemValidation(req.body)
+        const updatedInventoryItem: InventoryItemPutRequest = req.body
+        await MongoDriver.updateEntity(
+          InventoryItemSchema,
+          inventoryItemId,
+          updatedInventoryItem
+        )
+
+        return res.status(200).json({
+          success: true,
+          payload: {},
+        })
+      }
+      case 'DELETE': {
+        await MongoDriver.deleteEntity(InventoryItemSchema, inventoryItemId)
+
+        return res.status(200).json({
+          success: true,
+          payload: {},
+        })
+      }
+      default: {
+        throw new ApiError(405, 'Method Not Allowed')
+      }
+    }
+  } catch (e) {
+    console.log(e)
+    if (e instanceof ApiError) {
+      return res.status(e.statusCode).json({
+        success: false,
+        message: e.message,
+      })
+    }
+  }
+}

--- a/pages/api/inventoryItems/index.tsx
+++ b/pages/api/inventoryItems/index.tsx
@@ -8,7 +8,7 @@ import { apiInventoryItemValidation } from 'utils/apiValidators'
 
 // @route GET api/inventoryItems - Returns a list of all inventoryItems in the database - Private
 // @route POST /api/inventoryItems - Create a inventoryItems from request body - Private
-export default async function handler(
+export default async function inventoryItemsHandler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {

--- a/pages/api/inventoryItems/index.tsx
+++ b/pages/api/inventoryItems/index.tsx
@@ -35,7 +35,7 @@ export default async function handler(
 
         return res.status(201).json({
           success: true,
-          payload: response.id,
+          payload: response._id,
         })
       }
       default: {

--- a/pages/api/inventoryItems/index.tsx
+++ b/pages/api/inventoryItems/index.tsx
@@ -1,0 +1,53 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { ApiError, InventoryItem, InventoryItemPostRequest } from 'utils/types'
+import { serverAuth } from 'utils/auth'
+import { getInventoryItems } from 'server/actions/InventoryItems'
+import * as MongoDriver from 'server/actions/MongoDriver'
+import InventoryItemSchema from 'server/models/InventoryItem'
+import { apiInventoryItemValidation } from 'utils/apiValidators'
+
+// @route GET api/inventoryItems - Returns a list of all inventoryItems in the database - Private
+// @route POST /api/inventoryItems - Create a inventoryItems from request body - Private
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  try {
+    // ensure user is logged in
+    await serverAuth(req, res)
+
+    switch (req.method) {
+      case 'GET': {
+        const items = await getInventoryItems()
+        const resStatus = items.length ? 200 : 204
+        return res.status(resStatus).json({
+          success: true,
+          payload: items,
+        })
+      }
+      case 'POST': {
+        apiInventoryItemValidation(req.body)
+        const inventoryItem: InventoryItemPostRequest = req.body
+        const response = await MongoDriver.createEntity(
+          InventoryItemSchema,
+          inventoryItem
+        )
+
+        return res.status(201).json({
+          success: true,
+          payload: response.id,
+        })
+      }
+      default: {
+        throw new ApiError(405, 'Method Not Allowed')
+      }
+    }
+  } catch (e) {
+    if (e instanceof ApiError) {
+      return res.status(e.statusCode).json({
+        success: false,
+        message: e.message,
+      })
+    }
+  }
+}

--- a/pages/api/itemDefinitions/[itemDefinitionId].ts
+++ b/pages/api/itemDefinitions/[itemDefinitionId].ts
@@ -17,7 +17,7 @@ import constants from 'utils/constants'
 // @route GET api/itemDefintions/[itemDefinitionId] - Returns a single ItemDefinition object given a itemDefinitionId - Private
 // @route PUT api/users/[itemDefinitionId] - Updates an existing ItemDefinition object (identified by itemDefinitionId) with a new ItemDefinition object - Private
 // @route DELETE api/users/[itemDefinitionId] - Deletes a single ItemDefinition object (identified by itemDefinitionId) - Private
-export default async function handler(
+export default async function itemDefinitionHandler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {

--- a/pages/api/itemDefinitions/index.ts
+++ b/pages/api/itemDefinitions/index.ts
@@ -13,7 +13,7 @@ import constants from 'utils/constants'
 
 // @route GET api/itemDefintions - Returns a list of all itemDefintions in the database - Private
 // @route POST /api/itemDefintions - Create a itemDefinition from request body - Private
-export default async function handler(
+export default async function itemDefinitionsHandler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {

--- a/pages/api/users/[userId].ts
+++ b/pages/api/users/[userId].ts
@@ -9,7 +9,7 @@ import constants from 'utils/constants'
 // @route   GET api/users/[userId] - Returns a single User object for user with userId - Private
 // @route   DELETE api/users/[userId] - Deletes a single User object for user with userId - Private
 // @route   PUT api/users/[userId] - Updates a the existing User object with _id of userId with the new user - Private
-export default async function handler(
+export default async function userHandler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {

--- a/pages/api/users/index.ts
+++ b/pages/api/users/index.ts
@@ -7,7 +7,7 @@ import UserSchema from 'server/models/User'
 import constants from 'utils/constants'
 
 // @route   POST /api/users - Create a user from request body. - Public
-export default async function handler(
+export default async function usersHandler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {

--- a/pages/inventory.tsx
+++ b/pages/inventory.tsx
@@ -1,7 +1,7 @@
 import InventoryItemList from 'components/InventoryItemList'
 import { InventoryItemResponse } from 'utils/types'
 import { createRequest, createResponse, Headers } from 'node-mocks-http'
-import handler from 'pages/api/inventoryItems'
+import inventoryItemsHandler from 'pages/api/inventoryItems'
 import { Typography } from '@mui/material'
 import {
   GetServerSidePropsContext,
@@ -11,7 +11,7 @@ import {
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const res = createResponse()
-  await handler(context.req as NextApiRequest, res)
+  await inventoryItemsHandler(context.req as NextApiRequest, res)
   const responseData: InventoryItemResponse[] = res._getJSONData().payload
   return {
     props: { inventoryItems: responseData },

--- a/pages/inventory.tsx
+++ b/pages/inventory.tsx
@@ -1,32 +1,34 @@
 import InventoryItemList from 'components/InventoryItemList'
 import { InventoryItemResponse } from 'utils/types'
-import { useState, useEffect } from 'react'
+import { createRequest, createResponse, Headers } from 'node-mocks-http'
+import handler from 'pages/api/inventoryItems'
+import { Typography } from '@mui/material'
+import {
+  GetServerSidePropsContext,
+  NextApiRequest,
+  NextApiResponse,
+} from 'next'
 
-export default function InventoryPage() {
-  const [inventoryItems, setInventoryItems] = useState<InventoryItemResponse[]>(
-    []
-  )
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  const res = createResponse()
+  await handler(context.req as NextApiRequest, res)
+  const responseData: InventoryItemResponse[] = res._getJSONData().payload
+  return {
+    props: { inventoryItems: responseData },
+  }
+}
+interface Props {
+  inventoryItems: InventoryItemResponse[]
+}
 
-  useEffect(() => {
-    // TODO in the future, get a better way of constructing this URL. Perhaps a utils/urls.ts
-    fetch(`http://localhost:3000/api/inventoryItems`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    })
-      .then((res) => res.json())
-      .then((res) => setInventoryItems(res.payload as InventoryItemResponse[]))
-  }, [])
+export default function InventoryPage({ inventoryItems }: Props) {
   return (
     <>
-      {inventoryItems != null && (
-        <InventoryItemList
-          inventoryItems={inventoryItems}
-          search={''}
-          category={''}
-        />
-      )}
+      <InventoryItemList
+        inventoryItems={inventoryItems}
+        search={''}
+        category={''}
+      />
     </>
   )
 }

--- a/pages/inventory.tsx
+++ b/pages/inventory.tsx
@@ -1,5 +1,33 @@
-export default function InventoryPage() {
+import InventoryItemList from 'components/InventoryItemList'
+import { InventoryItem, InventoryItemResponse } from 'utils/types'
+import { createRequest, createResponse } from 'node-mocks-http'
+import handler from 'pages/api/inventoryItems'
+
+export async function getServerSideProps() {
+  const request = createRequest({
+    method: 'GET',
+    url: `api/inventoryItems`,
+  })
+  const response = createResponse()
+  const res = await handler(request, response)
+  return {
+    props: {},
+  }
+}
+interface Props {
+  inventoryItems: InventoryItemResponse[]
+}
+
+export default function InventoryPage({ inventoryItems }: Props) {
   return (
-    <h1>Inventory</h1>
+    <>
+      {inventoryItems != null && (
+        <InventoryItemList
+          inventoryItems={inventoryItems}
+          search={''}
+          category={''}
+        />
+      )}
+    </>
   )
 }

--- a/pages/inventory.tsx
+++ b/pages/inventory.tsx
@@ -1,24 +1,23 @@
 import InventoryItemList from 'components/InventoryItemList'
-import { InventoryItem, InventoryItemResponse } from 'utils/types'
-import { createRequest, createResponse } from 'node-mocks-http'
-import handler from 'pages/api/inventoryItems'
+import { InventoryItemResponse } from 'utils/types'
+import { useState, useEffect } from 'react'
 
-export async function getServerSideProps() {
-  const request = createRequest({
-    method: 'GET',
-    url: `api/inventoryItems`,
-  })
-  const response = createResponse()
-  const res = await handler(request, response)
-  return {
-    props: {},
-  }
-}
-interface Props {
-  inventoryItems: InventoryItemResponse[]
-}
+export default function InventoryPage() {
+  const [inventoryItems, setInventoryItems] = useState<InventoryItemResponse[]>(
+    []
+  )
 
-export default function InventoryPage({ inventoryItems }: Props) {
+  useEffect(() => {
+    // TODO in the future, get a better way of constructing this URL. Perhaps a utils/urls.ts
+    fetch(`http://localhost:3000/api/inventoryItems`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((res) => res.json())
+      .then((res) => setInventoryItems(res.payload as InventoryItemResponse[]))
+  }, [])
   return (
     <>
       {inventoryItems != null && (

--- a/server/actions/InventoryItems.ts
+++ b/server/actions/InventoryItems.ts
@@ -7,6 +7,124 @@ import {
 } from 'utils/types'
 import { ApiError } from 'utils/types'
 import { apiInventoryItemValidation } from 'utils/apiValidators'
+import { PipelineStage } from 'mongoose'
+
+// aggregate pipeline does the following:
+// looks up itemDefinition _id in inventoryItem
+// looks up categroy _id in itemDefinition
+// looks up attribute _ids in itemDefinition
+// looks up attribte _ids in inventoryItem
+// looks up user _ids in inventoryItem
+const requestPipeline: PipelineStage[] = [
+  {
+    $lookup: {
+      from: 'itemDefinitions',
+      let: { itemDefinitions: '$itemDefinitions' },
+      pipeline: [
+        {
+          $lookup: {
+            from: 'categories',
+            localField: 'category',
+            foreignField: '_id',
+            as: 'category',
+          },
+        },
+        {
+          $lookup: {
+            from: 'attributes',
+            localField: 'attributes',
+            foreignField: '_id',
+            as: 'attributes',
+          },
+        },
+        {
+          $set: {
+            category: { $arrayElemAt: ['$category', 0] },
+          },
+        },
+      ],
+      localField: 'itemDefinition',
+      foreignField: '_id',
+      as: 'itemDefinition',
+    },
+  },
+  // creates a temporary array of attribute documents called 'attributeDocs' containing all relevant attribute documents
+  {
+    $lookup: {
+      from: 'attributes',
+      localField: 'attributes.attribute',
+      foreignField: '_id',
+      as: 'attributeDocs',
+    },
+  },
+  // the above lookup only gets the attribute docs from the 'attributes' collection.
+  // It does not generate the inventoryItem attribute/value pairs.
+  {
+    $addFields: {
+      // builds out the inventoryItem.attributes array from scratch
+      attributes: {
+        // for every attribute in inventoryItem.attributes object, create an attribute/value pair
+        $map: {
+          input: '$attributes',
+          as: 'attr', // attribute from the inventoryItem.attributes array
+          in: {
+            attribute: {
+              // find the corresponding document from the attributes collection with the same _id
+              $arrayElemAt: [
+                {
+                  $filter: {
+                    input: '$attributeDocs',
+                    as: 'doc', // document from the attributes collection
+                    cond: { $eq: ['$$doc._id', '$$attr.attribute'] },
+                  },
+                },
+                0,
+              ],
+            },
+            // set the inventoryItem.attributes[i].value to its original value
+            value: '$$attr.value',
+          },
+        },
+      },
+    },
+  },
+  // delete the temporary array of attribute documents
+  {
+    $project: {
+      attributeDocs: 0,
+    },
+  },
+  {
+    $lookup: {
+      from: 'users',
+      localField: 'assignee',
+      foreignField: '_id',
+      as: 'assignee',
+    },
+  },
+  {
+    $set: {
+      assignee: { $arrayElemAt: ['$assignee', 0] },
+    },
+  },
+]
+
+/**
+ * Finds all inventoryItems
+ * @returns All inventoryItems
+ */
+export async function getInventoryItems() {
+  return await MongoDriver.getEntities(InventoryItemSchema, requestPipeline)
+}
+
+/**
+ * Finds an itemDefinition by its id
+ * @id The id of the InventoryItem object to find
+ * @returns The InventoryItem with the given _id
+ */
+export async function getInventoryItem(id: string) {
+  return await MongoDriver.getEntity(InventoryItemSchema, id, requestPipeline)
+}
 
 /**
  * Checks to see if an item is in the inventory and will add to the quantity or

--- a/server/actions/ItemDefinition.ts
+++ b/server/actions/ItemDefinition.ts
@@ -1,6 +1,31 @@
 import ItemDefinitionSchema from 'server/models/ItemDefinition'
 import { getEntities, getEntity } from 'server/actions/MongoDriver'
 import { ItemDefinitionResponse } from 'utils/types'
+import { PipelineStage } from 'mongoose'
+
+const requestPipeline: PipelineStage[] = [
+  {
+    $lookup: {
+      from: 'categories',
+      localField: 'category',
+      foreignField: '_id',
+      as: 'category',
+    },
+  },
+  {
+    $lookup: {
+      from: 'attributes',
+      localField: 'attributes',
+      foreignField: '_id',
+      as: 'attributes',
+    },
+  },
+  {
+    $set: {
+      category: { $arrayElemAt: ['$category', 0] },
+    },
+  },
+]
 
 /**
  * Finds an itemDefinition by its id
@@ -8,29 +33,11 @@ import { ItemDefinitionResponse } from 'utils/types'
  * @returns The ItemDefinition given by the itemDefinition parameter
  */
 export async function getItemDefinition(id: string) {
-  return await getEntity(ItemDefinitionSchema, id, [
-    {
-      $lookup: {
-        from: 'categories',
-        localField: 'category',
-        foreignField: '_id',
-        as: 'category',
-      },
-    },
-    {
-      $lookup: {
-        from: 'attributes',
-        localField: 'attributes',
-        foreignField: '_id',
-        as: 'attributes',
-      },
-    },
-    {
-      $set: {
-        category: { $arrayElemAt: ['$category', 0] },
-      },
-    },
-  ]) as ItemDefinitionResponse
+  return (await getEntity(
+    ItemDefinitionSchema,
+    id,
+    requestPipeline
+  )) as ItemDefinitionResponse
 }
 
 /**
@@ -38,27 +45,8 @@ export async function getItemDefinition(id: string) {
  * @returns All itemDefinitions
  */
 export async function getItemDefinitions() {
-  return await getEntities(ItemDefinitionSchema, [
-    {
-      $lookup: {
-        from: 'categories',
-        localField: 'category',
-        foreignField: '_id',
-        as: 'category',
-      },
-    },
-    {
-      $lookup: {
-        from: 'attributes',
-        localField: 'attributes',
-        foreignField: '_id',
-        as: 'attributes',
-      },
-    },
-    {
-      $set: {
-        category: { $arrayElemAt: ['$category', 0] },
-      },
-    },
-  ]) as ItemDefinitionResponse[]
+  return (await getEntities(
+    ItemDefinitionSchema,
+    requestPipeline
+  )) as ItemDefinitionResponse[]
 }

--- a/server/actions/MongoDriver.ts
+++ b/server/actions/MongoDriver.ts
@@ -8,7 +8,12 @@ import {
   Types,
 } from 'mongoose'
 import 'utils/types'
-import { ApiError, ServerModel, ServerPostRequest, ServerPutRequest, ServerRequest } from 'utils/types'
+import {
+  ApiError,
+  ServerModel,
+  ServerPostRequest,
+  ServerPutRequest,
+} from 'utils/types'
 import { ObjectId } from 'mongodb'
 
 const ENTITY_NOT_FOUND_MESSAGE = 'Entity does not exist'
@@ -105,6 +110,9 @@ export async function deleteEntity<Schema extends Document>(
 ): Promise<void> {
   await mongoDb()
 
+  // mixing async/await and the callback causes the call to succeed, but it generatees an uncaught error.
+  // TODO fix so that 404s can still be thrown, but without using callbacks
+  // https://stackoverflow.com/questions/69346158/mongooseerror-query-was-already-executed-user-countdocuments
   const response = await dbSchema.findByIdAndDelete(id)
   if (!response) {
     throw new ApiError(404, ENTITY_NOT_FOUND_MESSAGE)

--- a/server/actions/MongoDriver.ts
+++ b/server/actions/MongoDriver.ts
@@ -110,9 +110,6 @@ export async function deleteEntity<Schema extends Document>(
 ): Promise<void> {
   await mongoDb()
 
-  // mixing async/await and the callback causes the call to succeed, but it generatees an uncaught error.
-  // TODO fix so that 404s can still be thrown, but without using callbacks
-  // https://stackoverflow.com/questions/69346158/mongooseerror-query-was-already-executed-user-countdocuments
   const response = await dbSchema.findByIdAndDelete(id)
   if (!response) {
     throw new ApiError(404, ENTITY_NOT_FOUND_MESSAGE)

--- a/test/api/attributes/[attributeId].test.ts
+++ b/test/api/attributes/[attributeId].test.ts
@@ -1,6 +1,6 @@
 import { ObjectId } from 'mongodb'
 import AttributeSchema, { AttributeDocument } from 'server/models/Attribute'
-import { ApiError, AttributeResponse } from 'utils/types'
+import { ApiError } from 'utils/types'
 import { createRequest, createResponse } from 'node-mocks-http'
 import handler from 'pages/api/attributes/[attributeId]'
 import * as auth from 'utils/auth'
@@ -9,6 +9,7 @@ import * as apiValidator from 'utils/apiValidators'
 import mongoose from 'mongoose'
 import { clientPromise } from '@api/auth/[...nextauth]'
 import constants from 'utils/constants'
+import { validAttributeResponse, mockObjectId } from 'test/testData'
 
 beforeAll(() => {
   jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
@@ -25,8 +26,6 @@ afterAll(() => {
 
 describe('api/attributes/[attributeId]', () => {
   test('thrown error is caught, response is unsuccessful and shows correct error message', async () => {
-    const mockObjectId = '6408a7156668c5655c25b105'
-
     jest.spyOn(auth, 'serverAuth').mockImplementationOnce(async () => {
       throw new ApiError(401, constants.errors.unauthorized)
     })
@@ -50,8 +49,6 @@ describe('api/attributes/[attributeId]', () => {
   })
 
   test('unsupported method returns 405', async () => {
-    const mockObjectId = '6408a7156668c5655c25b105'
-
     const request = createRequest({
       method: 'POST',
       url: `/api/attributes/${mockObjectId}`,
@@ -71,13 +68,11 @@ describe('api/attributes/[attributeId]', () => {
   })
   describe('GET', () => {
     test('valid call returns correct data', async () => {
-      const mockObjectId = '6408a7156668c5655c25b105'
-
       const mockGetEntity = jest
         .spyOn(MongoDriver, 'getEntity')
         .mockImplementation(
           async () =>
-            validAttributeResponse as AttributeDocument & { _id: ObjectId }
+            validAttributeResponse[0] as AttributeDocument & { _id: ObjectId }
         )
 
       const request = createRequest({
@@ -96,14 +91,12 @@ describe('api/attributes/[attributeId]', () => {
       expect(mockGetEntity).toHaveBeenCalledTimes(1)
       expect(mockGetEntity).lastCalledWith(AttributeSchema, mockObjectId)
       expect(response.statusCode).toBe(200)
-      expect(data).toEqual(validAttributeResponse)
+      expect(data).toEqual(validAttributeResponse[0])
     })
   })
 
   describe('PUT', () => {
     test('valid call returns correct data', async () => {
-      const mockObjectId = '6408a7156668c5655c25b105'
-
       const mockUpdateEntity = jest
         .spyOn(MongoDriver, 'updateEntity')
         // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -140,7 +133,6 @@ describe('api/attributes/[attributeId]', () => {
 
   describe('DELETE', () => {
     test('valid id returns correct data', async () => {
-      const mockObjectId = '6408a7156668c5655c25b105'
       const mockDeleteEntity = jest
         .spyOn(MongoDriver, 'deleteEntity')
         // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -163,9 +155,3 @@ describe('api/attributes/[attributeId]', () => {
     })
   })
 })
-const validAttributeResponse: AttributeResponse = {
-  _id: '1',
-  name: 'test',
-  possibleValues: 'text',
-  color: '#000000',
-}

--- a/test/api/attributes/[attributeId].test.ts
+++ b/test/api/attributes/[attributeId].test.ts
@@ -9,7 +9,11 @@ import * as apiValidator from 'utils/apiValidators'
 import mongoose from 'mongoose'
 import { clientPromise } from '@api/auth/[...nextauth]'
 import constants from 'utils/constants'
-import { validAttributeResponse, mockObjectId } from 'test/testData'
+import {
+  validAttributeResponse,
+  mockObjectId,
+  validAttributePutRequest,
+} from 'test/testData'
 
 beforeAll(() => {
   jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
@@ -111,7 +115,7 @@ describe('api/attributes/[attributeId]', () => {
         query: {
           attributeId: mockObjectId,
         },
-        body: validAttributeResponse,
+        body: validAttributePutRequest,
       })
 
       const response = createResponse()
@@ -124,7 +128,7 @@ describe('api/attributes/[attributeId]', () => {
       expect(mockUpdateEntity).lastCalledWith(
         AttributeSchema,
         mockObjectId,
-        validAttributeResponse
+        validAttributePutRequest
       )
       expect(response.statusCode).toBe(200)
       expect(data).toEqual({})

--- a/test/api/attributes/[attributeId].test.ts
+++ b/test/api/attributes/[attributeId].test.ts
@@ -2,7 +2,7 @@ import { ObjectId } from 'mongodb'
 import AttributeSchema, { AttributeDocument } from 'server/models/Attribute'
 import { ApiError } from 'utils/types'
 import { createRequest, createResponse } from 'node-mocks-http'
-import handler from 'pages/api/attributes/[attributeId]'
+import attributeHandler from 'pages/api/attributes/[attributeId]'
 import * as auth from 'utils/auth'
 import * as MongoDriver from 'server/actions/MongoDriver'
 import * as apiValidator from 'utils/apiValidators'
@@ -43,7 +43,7 @@ describe('api/attributes/[attributeId]', () => {
     })
     const response = createResponse()
 
-    await handler(request, response)
+    await attributeHandler(request, response)
 
     const data = response._getJSONData()
 
@@ -62,7 +62,7 @@ describe('api/attributes/[attributeId]', () => {
     })
     const response = createResponse()
 
-    await handler(request, response)
+    await attributeHandler(request, response)
 
     const data = response._getJSONData()
 
@@ -89,7 +89,7 @@ describe('api/attributes/[attributeId]', () => {
 
       const response = createResponse()
 
-      await handler(request, response)
+      await attributeHandler(request, response)
       const data = response._getJSONData().payload
 
       expect(mockGetEntity).toHaveBeenCalledTimes(1)
@@ -120,7 +120,7 @@ describe('api/attributes/[attributeId]', () => {
 
       const response = createResponse()
 
-      await handler(request, response)
+      await attributeHandler(request, response)
       const data = response._getJSONData().payload
 
       expect(mockApiAttributeValidation).toHaveBeenCalledTimes(1)
@@ -150,7 +150,7 @@ describe('api/attributes/[attributeId]', () => {
       })
       const response = createResponse()
 
-      await handler(request, response)
+      await attributeHandler(request, response)
 
       expect(mockDeleteEntity).toHaveBeenCalledTimes(1)
       expect(mockDeleteEntity).lastCalledWith(AttributeSchema, mockObjectId)

--- a/test/api/attributes/index.test.ts
+++ b/test/api/attributes/index.test.ts
@@ -119,12 +119,7 @@ describe('api/attributes', () => {
         .spyOn(MongoDriver, 'createEntity')
         .mockImplementation(
           async () =>
-            ({
-              ...validAttributeResponse[0],
-              _id: mockObjectId,
-            } as AttributeDocument & {
-              _id: ObjectId
-            })
+            validAttributeResponse[0] as AttributeDocument & { _id: ObjectId }
         )
       const mockApiAttributeValidation = jest
         .spyOn(apiValidator, 'apiAttributeValidation')

--- a/test/api/attributes/index.test.ts
+++ b/test/api/attributes/index.test.ts
@@ -2,7 +2,7 @@ import { ObjectId } from 'mongodb'
 import AttributeSchema, { AttributeDocument } from 'server/models/Attribute'
 import { ApiError } from 'utils/types'
 import { createRequest, createResponse } from 'node-mocks-http'
-import handler from 'pages/api/attributes'
+import attributesHandler from 'pages/api/attributes'
 import * as auth from 'utils/auth'
 import * as MongoDriver from 'server/actions/MongoDriver'
 import * as apiValidator from 'utils/apiValidators'
@@ -38,7 +38,7 @@ describe('api/attributes', () => {
     })
     const response = createResponse()
 
-    await handler(request, response)
+    await attributesHandler(request, response)
 
     const data = response._getJSONData()
 
@@ -54,7 +54,7 @@ describe('api/attributes', () => {
     })
     const response = createResponse()
 
-    await handler(request, response)
+    await attributesHandler(request, response)
 
     const data = response._getJSONData()
 
@@ -81,7 +81,7 @@ describe('api/attributes', () => {
 
       const response = createResponse()
 
-      await handler(request, response)
+      await attributesHandler(request, response)
       const data = response._getJSONData().payload
 
       expect(serverAuth).toHaveBeenCalledTimes(1)
@@ -103,7 +103,7 @@ describe('api/attributes', () => {
 
       const response = createResponse()
 
-      await handler(request, response)
+      await attributesHandler(request, response)
       const data = response._getJSONData().payload
 
       expect(mockGetEntities).toHaveBeenCalledTimes(1)
@@ -133,7 +133,7 @@ describe('api/attributes', () => {
 
       const response = createResponse()
 
-      await handler(request, response)
+      await attributesHandler(request, response)
       const data = response._getJSONData().payload
 
       expect(mockApiAttributeValidation).toHaveBeenCalledTimes(1)

--- a/test/api/categories/[categoryId].test.ts
+++ b/test/api/categories/[categoryId].test.ts
@@ -9,7 +9,11 @@ import * as apiValidator from 'utils/apiValidators'
 import mongoose from 'mongoose'
 import { clientPromise } from '@api/auth/[...nextauth]'
 import constants from 'utils/constants'
-import { validCategoryResponse, mockObjectId } from 'test/testData'
+import {
+  validCategoryResponse,
+  mockObjectId,
+  validCategoryPutRequest,
+} from 'test/testData'
 
 beforeAll(() => {
   jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
@@ -113,7 +117,7 @@ describe('api/categories/[categoryId]', () => {
         query: {
           categoryId: mockObjectId,
         },
-        body: validCategoryResponse,
+        body: validCategoryPutRequest,
       })
 
       const response = createResponse()
@@ -126,7 +130,7 @@ describe('api/categories/[categoryId]', () => {
       expect(mockUpdateEntity).lastCalledWith(
         CategorySchema,
         mockObjectId,
-        validCategoryResponse
+        validCategoryPutRequest
       )
       expect(response.statusCode).toBe(200)
       expect(data).toEqual({})

--- a/test/api/categories/[categoryId].test.ts
+++ b/test/api/categories/[categoryId].test.ts
@@ -2,7 +2,7 @@ import { ObjectId } from 'mongodb'
 import CategorySchema, { CategoryDocument } from 'server/models/Category'
 import { ApiError } from 'utils/types'
 import { createRequest, createResponse } from 'node-mocks-http'
-import handler from 'pages/api/categories/[categoryId]'
+import categoryHandler from 'pages/api/categories/[categoryId]'
 import * as auth from 'utils/auth'
 import * as MongoDriver from 'server/actions/MongoDriver'
 import * as apiValidator from 'utils/apiValidators'
@@ -43,7 +43,7 @@ describe('api/categories/[categoryId]', () => {
     })
     const response = createResponse()
 
-    await handler(request, response)
+    await categoryHandler(request, response)
 
     const data = response._getJSONData()
 
@@ -62,7 +62,7 @@ describe('api/categories/[categoryId]', () => {
     })
     const response = createResponse()
 
-    await handler(request, response)
+    await categoryHandler(request, response)
 
     const data = response._getJSONData()
 
@@ -90,7 +90,7 @@ describe('api/categories/[categoryId]', () => {
 
       const response = createResponse()
 
-      await handler(request, response)
+      await categoryHandler(request, response)
       const data = response._getJSONData().payload
 
       expect(mockGetEntity).toHaveBeenCalledTimes(1)
@@ -122,7 +122,7 @@ describe('api/categories/[categoryId]', () => {
 
       const response = createResponse()
 
-      await handler(request, response)
+      await categoryHandler(request, response)
       const data = response._getJSONData().payload
 
       expect(mockApiCategoryValidation).toHaveBeenCalledTimes(1)
@@ -152,7 +152,7 @@ describe('api/categories/[categoryId]', () => {
       })
       const response = createResponse()
 
-      await handler(request, response)
+      await categoryHandler(request, response)
 
       expect(mockDeleteEntity).toHaveBeenCalledTimes(1)
       expect(mockDeleteEntity).lastCalledWith(CategorySchema, mockObjectId)

--- a/test/api/categories/index.test.ts
+++ b/test/api/categories/index.test.ts
@@ -2,7 +2,7 @@ import { ObjectId } from 'mongodb'
 import CategorySchema, { CategoryDocument } from 'server/models/Category'
 import { ApiError } from 'utils/types'
 import { createRequest, createResponse } from 'node-mocks-http'
-import handler from 'pages/api/categories'
+import categoriesHandler from 'pages/api/categories'
 import * as auth from 'utils/auth'
 import * as MongoDriver from 'server/actions/MongoDriver'
 import * as apiValidator from 'utils/apiValidators'
@@ -42,7 +42,7 @@ describe('api/categories', () => {
     })
     const response = createResponse()
 
-    await handler(request, response)
+    await categoriesHandler(request, response)
 
     const data = response._getJSONData()
 
@@ -58,7 +58,7 @@ describe('api/categories', () => {
     })
     const response = createResponse()
 
-    await handler(request, response)
+    await categoriesHandler(request, response)
 
     const data = response._getJSONData()
 
@@ -85,7 +85,7 @@ describe('api/categories', () => {
 
       const response = createResponse()
 
-      await handler(request, response)
+      await categoriesHandler(request, response)
       const data = response._getJSONData().payload
 
       expect(serverAuth).toHaveBeenCalledTimes(1)
@@ -107,7 +107,7 @@ describe('api/categories', () => {
 
       const response = createResponse()
 
-      await handler(request, response)
+      await categoriesHandler(request, response)
       const data = response._getJSONData().payload
 
       expect(mockGetEntities).toHaveBeenCalledTimes(1)
@@ -137,7 +137,7 @@ describe('api/categories', () => {
 
       const response = createResponse()
 
-      await handler(request, response)
+      await categoriesHandler(request, response)
       const data = response._getJSONData().payload
 
       expect(mockApiCategoryValidation).toHaveBeenCalledTimes(1)

--- a/test/api/categories/index.test.ts
+++ b/test/api/categories/index.test.ts
@@ -1,6 +1,6 @@
 import { ObjectId } from 'mongodb'
 import CategorySchema, { CategoryDocument } from 'server/models/Category'
-import { ApiError, CategoryResponse } from 'utils/types'
+import { ApiError } from 'utils/types'
 import { createRequest, createResponse } from 'node-mocks-http'
 import handler from 'pages/api/categories'
 import * as auth from 'utils/auth'
@@ -9,6 +9,7 @@ import * as apiValidator from 'utils/apiValidators'
 import mongoose from 'mongoose'
 import { clientPromise } from '@api/auth/[...nextauth]'
 import constants from 'utils/constants'
+import { validCategoryResponse, mockObjectId } from 'test/testData'
 
 beforeAll(() => {
   jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
@@ -114,14 +115,13 @@ describe('api/categories', () => {
 
   describe('POST', () => {
     test('valid call returns correct data', async () => {
-      const fakeObjectId = '5f9f1c7b9c9b9b0b0c0c0c0c'
       const mockCreateEntity = jest
         .spyOn(MongoDriver, 'createEntity')
         .mockImplementation(
           async () =>
             ({
               ...validCategoryResponse[0],
-              _id: fakeObjectId,
+              _id: mockObjectId,
             } as CategoryDocument & {
               _id: ObjectId
             })
@@ -148,13 +148,7 @@ describe('api/categories', () => {
         validCategoryResponse[0]
       )
       expect(response.statusCode).toBe(201)
-      expect(data).toEqual(fakeObjectId)
+      expect(data).toEqual(mockObjectId)
     })
   })
 })
-const validCategoryResponse: CategoryResponse[] = [
-  {
-    _id: '1',
-    name: 'test',
-  },
-]

--- a/test/api/categories/index.test.ts
+++ b/test/api/categories/index.test.ts
@@ -9,7 +9,11 @@ import * as apiValidator from 'utils/apiValidators'
 import mongoose from 'mongoose'
 import { clientPromise } from '@api/auth/[...nextauth]'
 import constants from 'utils/constants'
-import { validCategoryResponse, mockObjectId } from 'test/testData'
+import {
+  validCategoryResponse,
+  mockObjectId,
+  validCategoryPostRequest,
+} from 'test/testData'
 
 beforeAll(() => {
   jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
@@ -119,12 +123,7 @@ describe('api/categories', () => {
         .spyOn(MongoDriver, 'createEntity')
         .mockImplementation(
           async () =>
-            ({
-              ...validCategoryResponse[0],
-              _id: mockObjectId,
-            } as CategoryDocument & {
-              _id: ObjectId
-            })
+            validCategoryResponse[0] as CategoryDocument & { _id: ObjectId }
         )
       const mockApiCategoryValidation = jest
         .spyOn(apiValidator, 'apiCategoryValidation')
@@ -133,7 +132,7 @@ describe('api/categories', () => {
       const request = createRequest({
         method: 'POST',
         url: `/api/categories`,
-        body: validCategoryResponse[0],
+        body: validCategoryPostRequest,
       })
 
       const response = createResponse()
@@ -145,7 +144,7 @@ describe('api/categories', () => {
       expect(mockCreateEntity).toHaveBeenCalledTimes(1)
       expect(mockCreateEntity).lastCalledWith(
         CategorySchema,
-        validCategoryResponse[0]
+        validCategoryPostRequest
       )
       expect(response.statusCode).toBe(201)
       expect(data).toEqual(mockObjectId)

--- a/test/api/inventoryItems/[inventoryItemId].test.ts
+++ b/test/api/inventoryItems/[inventoryItemId].test.ts
@@ -11,7 +11,11 @@ import * as MongoDriver from 'server/actions/MongoDriver'
 import * as apiValidator from 'utils/apiValidators'
 import { clientPromise } from '@api/auth/[...nextauth]'
 import constants from 'utils/constants'
-import { validInventoryItemResponse, mockObjectId } from 'test/testData'
+import {
+  validInventoryItemResponse,
+  mockObjectId,
+  validInventoryItemPutRequest,
+} from 'test/testData'
 
 // TODO: add assertion for GET 'called with' aggregate stuff
 // this may need to have different functionality
@@ -116,7 +120,7 @@ describe('api/inventoryItems/[inventoryItemId]', () => {
         query: {
           inventoryItemId: mockObjectId,
         },
-        body: validInventoryItemResponse,
+        body: validInventoryItemPutRequest,
       })
 
       const response = createResponse()
@@ -129,7 +133,7 @@ describe('api/inventoryItems/[inventoryItemId]', () => {
       expect(mockUpdateEntity).lastCalledWith(
         InventoryItemSchema,
         mockObjectId,
-        validInventoryItemResponse
+        validInventoryItemPutRequest
       )
       expect(response.statusCode).toBe(200)
       expect(data).toEqual({})

--- a/test/api/inventoryItems/[inventoryItemId].test.ts
+++ b/test/api/inventoryItems/[inventoryItemId].test.ts
@@ -5,7 +5,7 @@ import InventoryItemSchema, {
 } from 'server/models/InventoryItem'
 import { ApiError } from 'utils/types'
 import { createRequest, createResponse } from 'node-mocks-http'
-import handler from 'pages/api/inventoryItems/[inventoryItemId]'
+import inventoryItemHandler from 'pages/api/inventoryItems/[inventoryItemId]'
 import * as auth from 'utils/auth'
 import * as MongoDriver from 'server/actions/MongoDriver'
 import * as apiValidator from 'utils/apiValidators'
@@ -46,7 +46,7 @@ describe('api/inventoryItems/[inventoryItemId]', () => {
     })
     const response = createResponse()
 
-    await handler(request, response)
+    await inventoryItemHandler(request, response)
 
     const data = response._getJSONData()
 
@@ -65,7 +65,7 @@ describe('api/inventoryItems/[inventoryItemId]', () => {
     })
     const response = createResponse()
 
-    await handler(request, response)
+    await inventoryItemHandler(request, response)
 
     const data = response._getJSONData()
 
@@ -94,7 +94,7 @@ describe('api/inventoryItems/[inventoryItemId]', () => {
 
       const response = createResponse()
 
-      await handler(request, response)
+      await inventoryItemHandler(request, response)
       const data = response._getJSONData().payload
 
       expect(mockGetEntity).toHaveBeenCalledTimes(1)
@@ -125,7 +125,7 @@ describe('api/inventoryItems/[inventoryItemId]', () => {
 
       const response = createResponse()
 
-      await handler(request, response)
+      await inventoryItemHandler(request, response)
       const data = response._getJSONData().payload
 
       expect(mockApiInventoryItemValidation).toHaveBeenCalledTimes(1)
@@ -155,7 +155,7 @@ describe('api/inventoryItems/[inventoryItemId]', () => {
       })
       const response = createResponse()
 
-      await handler(request, response)
+      await inventoryItemHandler(request, response)
 
       expect(mockDeleteEntity).toHaveBeenCalledTimes(1)
       expect(mockDeleteEntity).lastCalledWith(InventoryItemSchema, mockObjectId)

--- a/test/api/inventoryItems/[inventoryItemId].test.ts
+++ b/test/api/inventoryItems/[inventoryItemId].test.ts
@@ -1,30 +1,33 @@
+/* eslint-disable-next-line @typescript-eslint/no-empty-function */
 import { ObjectId } from 'mongodb'
-import CategorySchema, { CategoryDocument } from 'server/models/Category'
+import InventoryItemSchema, {
+  InventoryItemDocument,
+} from 'server/models/InventoryItem'
 import { ApiError } from 'utils/types'
 import { createRequest, createResponse } from 'node-mocks-http'
-import handler from 'pages/api/categories/[categoryId]'
+import handler from 'pages/api/inventoryItems/[inventoryItemId]'
 import * as auth from 'utils/auth'
 import * as MongoDriver from 'server/actions/MongoDriver'
 import * as apiValidator from 'utils/apiValidators'
-import mongoose from 'mongoose'
 import { clientPromise } from '@api/auth/[...nextauth]'
 import constants from 'utils/constants'
-import { validCategoryResponse, mockObjectId } from 'test/testData'
+import { validInventoryItemResponse, mockObjectId } from 'test/testData'
+
+// TODO: add assertion for GET 'called with' aggregate stuff
+// this may need to have different functionality
 
 beforeAll(() => {
   jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
-
   jest.spyOn(apiValidator, 'apiObjectIdValidation').mockImplementation()
 })
 
 // restore mocked implementations and close db connections
 afterAll(() => {
   jest.restoreAllMocks()
-  mongoose.connection.close()
   clientPromise.then((client) => client.close())
 })
 
-describe('api/categories/[categoryId]', () => {
+describe('api/inventoryItems/[inventoryItemId]', () => {
   test('thrown error is caught, response is unsuccessful and shows correct error message', async () => {
     jest.spyOn(auth, 'serverAuth').mockImplementationOnce(async () => {
       throw new ApiError(401, constants.errors.unauthorized)
@@ -32,9 +35,9 @@ describe('api/categories/[categoryId]', () => {
 
     const request = createRequest({
       method: 'GET',
-      url: `/api/categories/${mockObjectId}`,
+      url: `/api/inventoryItems/${mockObjectId}`,
       query: {
-        categoryId: mockObjectId,
+        inventoryItemId: mockObjectId,
       },
     })
     const response = createResponse()
@@ -51,9 +54,9 @@ describe('api/categories/[categoryId]', () => {
   test('unsupported method returns 405', async () => {
     const request = createRequest({
       method: 'POST',
-      url: `/api/categories/${mockObjectId}`,
+      url: `/api/inventoryItems/${mockObjectId}`,
       query: {
-        categoryId: mockObjectId,
+        inventoryItemId: mockObjectId,
       },
     })
     const response = createResponse()
@@ -66,21 +69,22 @@ describe('api/categories/[categoryId]', () => {
     expect(data.message).toBe(constants.errors.invalidReqMethod)
     expect(data.success).toBe(false)
   })
-
   describe('GET', () => {
     test('valid call returns correct data', async () => {
       const mockGetEntity = jest
         .spyOn(MongoDriver, 'getEntity')
         .mockImplementation(
           async () =>
-            validCategoryResponse[0] as CategoryDocument & { _id: ObjectId }
+            validInventoryItemResponse[0] as InventoryItemDocument & {
+              _id: ObjectId
+            }
         )
 
       const request = createRequest({
         method: 'GET',
-        url: `/api/categories/${mockObjectId}`,
+        url: `/api/inventoryItems/${mockObjectId}`,
         query: {
-          categoryId: mockObjectId,
+          inventoryItemId: mockObjectId,
         },
       })
 
@@ -90,30 +94,29 @@ describe('api/categories/[categoryId]', () => {
       const data = response._getJSONData().payload
 
       expect(mockGetEntity).toHaveBeenCalledTimes(1)
-      expect(mockGetEntity).lastCalledWith(CategorySchema, mockObjectId)
       expect(response.statusCode).toBe(200)
-      expect(data).toEqual(validCategoryResponse[0])
+      expect(data).toEqual(validInventoryItemResponse[0])
     })
   })
 
   describe('PUT', () => {
-    jest.spyOn(apiValidator, 'apiCategoryValidation').mockImplementation()
+    jest.spyOn(apiValidator, 'apiInventoryItemValidation').mockImplementation()
     test('valid call returns correct data', async () => {
       const mockUpdateEntity = jest
         .spyOn(MongoDriver, 'updateEntity')
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         .mockImplementation(async () => {})
-      const mockApiCategoryValidation = jest
-        .spyOn(apiValidator, 'apiCategoryValidation')
+      const mockApiInventoryItemValidation = jest
+        .spyOn(apiValidator, 'apiInventoryItemValidation')
         .mockImplementation()
 
       const request = createRequest({
         method: 'PUT',
-        url: `/api/categories/${mockObjectId}`,
+        url: `/api/inventoryItems/${mockObjectId}`,
         query: {
-          categoryId: mockObjectId,
+          inventoryItemId: mockObjectId,
         },
-        body: validCategoryResponse,
+        body: validInventoryItemResponse,
       })
 
       const response = createResponse()
@@ -121,12 +124,12 @@ describe('api/categories/[categoryId]', () => {
       await handler(request, response)
       const data = response._getJSONData().payload
 
-      expect(mockApiCategoryValidation).toHaveBeenCalledTimes(1)
+      expect(mockApiInventoryItemValidation).toHaveBeenCalledTimes(1)
       expect(mockUpdateEntity).toHaveBeenCalledTimes(1)
       expect(mockUpdateEntity).lastCalledWith(
-        CategorySchema,
+        InventoryItemSchema,
         mockObjectId,
-        validCategoryResponse
+        validInventoryItemResponse
       )
       expect(response.statusCode).toBe(200)
       expect(data).toEqual({})
@@ -141,9 +144,9 @@ describe('api/categories/[categoryId]', () => {
         .mockImplementation(async () => {})
       const request = createRequest({
         method: 'DELETE',
-        url: `/api/categories/${mockObjectId}`,
+        url: `/api/inventoryItems/${mockObjectId}`,
         query: {
-          categoryId: mockObjectId,
+          inventoryItemId: mockObjectId,
         },
       })
       const response = createResponse()
@@ -151,7 +154,7 @@ describe('api/categories/[categoryId]', () => {
       await handler(request, response)
 
       expect(mockDeleteEntity).toHaveBeenCalledTimes(1)
-      expect(mockDeleteEntity).lastCalledWith(CategorySchema, mockObjectId)
+      expect(mockDeleteEntity).lastCalledWith(InventoryItemSchema, mockObjectId)
       expect(response.statusCode).toBe(200)
       expect(response._getJSONData().payload).toEqual({})
     })

--- a/test/api/inventoryItems/index.test.ts
+++ b/test/api/inventoryItems/index.test.ts
@@ -10,7 +10,11 @@ import * as MongoDriver from 'server/actions/MongoDriver'
 import * as apiValidator from 'utils/apiValidators'
 import { clientPromise } from '@api/auth/[...nextauth]'
 import constants from 'utils/constants'
-import { validInventoryItemResponse, mockObjectId } from 'test/testData'
+import {
+  validInventoryItemResponse,
+  mockObjectId,
+  validInventoryItemPostRequest,
+} from 'test/testData'
 
 beforeAll(() => {
   jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
@@ -119,12 +123,9 @@ describe('api/inventoryItems', () => {
         .spyOn(MongoDriver, 'createEntity')
         .mockImplementation(
           async () =>
-            ({
-              ...validInventoryItemResponse[0],
-              _id: mockObjectId,
-            } as InventoryItemDocument & {
+            validInventoryItemResponse[0] as InventoryItemDocument & {
               _id: ObjectId
-            })
+            }
         )
       const mockApiInventoryItemValidation = jest
         .spyOn(apiValidator, 'apiInventoryItemValidation')
@@ -133,7 +134,7 @@ describe('api/inventoryItems', () => {
       const request = createRequest({
         method: 'POST',
         url: `/api/inventoryItems`,
-        body: validInventoryItemResponse[0],
+        body: validInventoryItemPostRequest,
       })
 
       const response = createResponse()
@@ -144,7 +145,7 @@ describe('api/inventoryItems', () => {
       expect(mockCreateEntity).toHaveBeenCalledTimes(1)
       expect(mockCreateEntity).lastCalledWith(
         InventoryItemSchema,
-        validInventoryItemResponse[0]
+        validInventoryItemPostRequest
       )
       expect(response.statusCode).toBe(201)
       expect(data).toEqual(mockObjectId)

--- a/test/api/inventoryItems/index.test.ts
+++ b/test/api/inventoryItems/index.test.ts
@@ -4,7 +4,7 @@ import InventoryItemSchema, {
 } from 'server/models/InventoryItem'
 import { ApiError } from 'utils/types'
 import { createRequest, createResponse } from 'node-mocks-http'
-import handler from 'pages/api/inventoryItems'
+import inventoryItemsHandler from 'pages/api/inventoryItems'
 import * as auth from 'utils/auth'
 import * as MongoDriver from 'server/actions/MongoDriver'
 import * as apiValidator from 'utils/apiValidators'
@@ -42,7 +42,7 @@ describe('api/inventoryItems', () => {
     })
     const response = createResponse()
 
-    await handler(request, response)
+    await inventoryItemsHandler(request, response)
 
     const data = response._getJSONData()
 
@@ -58,7 +58,7 @@ describe('api/inventoryItems', () => {
     })
     const response = createResponse()
 
-    await handler(request, response)
+    await inventoryItemsHandler(request, response)
 
     const data = response._getJSONData()
 
@@ -87,7 +87,7 @@ describe('api/inventoryItems', () => {
 
       const response = createResponse()
 
-      await handler(request, response)
+      await inventoryItemsHandler(request, response)
       const data = response._getJSONData().payload
 
       expect(serverAuth).toHaveBeenCalledTimes(1)
@@ -108,7 +108,7 @@ describe('api/inventoryItems', () => {
 
       const response = createResponse()
 
-      await handler(request, response)
+      await inventoryItemsHandler(request, response)
       const data = response._getJSONData().payload
 
       expect(mockGetEntities).toHaveBeenCalledTimes(1)
@@ -139,7 +139,7 @@ describe('api/inventoryItems', () => {
 
       const response = createResponse()
 
-      await handler(request, response)
+      await inventoryItemsHandler(request, response)
       const data = response._getJSONData().payload
       expect(mockApiInventoryItemValidation).toHaveBeenCalledTimes(1)
       expect(mockCreateEntity).toHaveBeenCalledTimes(1)

--- a/test/api/itemDefinitions/[itemDefinitionId].test.ts
+++ b/test/api/itemDefinitions/[itemDefinitionId].test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable-next-line @typescript-eslint/no-empty-function */
 import { ObjectId } from 'mongodb'
 import ItemDefinitionSchema, {
   ItemDefinitionDocument,
@@ -11,6 +10,7 @@ import * as MongoDriver from 'server/actions/MongoDriver'
 import * as apiValidator from 'utils/apiValidators'
 import { clientPromise } from '@api/auth/[...nextauth]'
 import constants from 'utils/constants'
+import { validItemDefinitionResponse, mockObjectId } from 'test/testData'
 
 // TODO: add assertion for GET 'called with' aggregate stuff
 // this may need to have different functionality
@@ -34,9 +34,9 @@ describe('api/itemDefinitions/[itemDefinitionId]', () => {
 
     const request = createRequest({
       method: 'GET',
-      url: `/api/itemDefinitions/${fakeObjectId}`,
+      url: `/api/itemDefinitions/${mockObjectId}`,
       query: {
-        itemDefinitionId: fakeObjectId,
+        itemDefinitionId: mockObjectId,
       },
     })
     const response = createResponse()
@@ -53,9 +53,9 @@ describe('api/itemDefinitions/[itemDefinitionId]', () => {
   test('unsupported method returns 405', async () => {
     const request = createRequest({
       method: 'POST',
-      url: `/api/itemDefinitions/${fakeObjectId}`,
+      url: `/api/itemDefinitions/${mockObjectId}`,
       query: {
-        itemDefinitionId: fakeObjectId,
+        itemDefinitionId: mockObjectId,
       },
     })
     const response = createResponse()
@@ -74,16 +74,16 @@ describe('api/itemDefinitions/[itemDefinitionId]', () => {
         .spyOn(MongoDriver, 'getEntity')
         .mockImplementation(
           async () =>
-            validItemDefinitionResponse as ItemDefinitionDocument & {
+            validItemDefinitionResponse[0] as ItemDefinitionDocument & {
               _id: ObjectId
             }
         )
 
       const request = createRequest({
         method: 'GET',
-        url: `/api/itemDefinitions/${fakeObjectId}`,
+        url: `/api/itemDefinitions/${mockObjectId}`,
         query: {
-          itemDefinitionId: fakeObjectId,
+          itemDefinitionId: mockObjectId,
         },
       })
 
@@ -94,7 +94,7 @@ describe('api/itemDefinitions/[itemDefinitionId]', () => {
 
       expect(mockGetEntity).toHaveBeenCalledTimes(1)
       expect(response.statusCode).toBe(200)
-      expect(data).toEqual(validItemDefinitionResponse)
+      expect(data).toEqual(validItemDefinitionResponse[0])
     })
   })
 
@@ -111,9 +111,9 @@ describe('api/itemDefinitions/[itemDefinitionId]', () => {
 
       const request = createRequest({
         method: 'PUT',
-        url: `/api/itemDefinitions/${fakeObjectId}`,
+        url: `/api/itemDefinitions/${mockObjectId}`,
         query: {
-          itemDefinitionId: fakeObjectId,
+          itemDefinitionId: mockObjectId,
         },
         body: validItemDefinitionResponse,
       })
@@ -127,7 +127,7 @@ describe('api/itemDefinitions/[itemDefinitionId]', () => {
       expect(mockUpdateEntity).toHaveBeenCalledTimes(1)
       expect(mockUpdateEntity).lastCalledWith(
         ItemDefinitionSchema,
-        fakeObjectId,
+        mockObjectId,
         validItemDefinitionResponse
       )
       expect(response.statusCode).toBe(200)
@@ -143,9 +143,9 @@ describe('api/itemDefinitions/[itemDefinitionId]', () => {
         .mockImplementation(async () => {})
       const request = createRequest({
         method: 'DELETE',
-        url: `/api/itemDefinitions/${fakeObjectId}`,
+        url: `/api/itemDefinitions/${mockObjectId}`,
         query: {
-          itemDefinitionId: fakeObjectId,
+          itemDefinitionId: mockObjectId,
         },
       })
       const response = createResponse()
@@ -155,31 +155,10 @@ describe('api/itemDefinitions/[itemDefinitionId]', () => {
       expect(mockDeleteEntity).toHaveBeenCalledTimes(1)
       expect(mockDeleteEntity).lastCalledWith(
         ItemDefinitionSchema,
-        fakeObjectId
+        mockObjectId
       )
       expect(response.statusCode).toBe(200)
       expect(response._getJSONData().payload).toEqual({})
     })
   })
 })
-const validItemDefinitionResponse: ItemDefinitionResponse = {
-  _id: '1',
-  name: 'Test Item',
-  internal: false,
-  lowStockThreshold: 10,
-  criticalStockThreshold: 5,
-  category: {
-    _id: '2',
-    name: 'Test Category',
-  },
-  attributes: [
-    {
-      _id: '3',
-      name: 'Test Attribute',
-      possibleValues: 'text',
-      color: '#000000',
-    },
-  ],
-}
-
-const fakeObjectId = '6408a7156668c5655c25b105'

--- a/test/api/itemDefinitions/[itemDefinitionId].test.ts
+++ b/test/api/itemDefinitions/[itemDefinitionId].test.ts
@@ -10,7 +10,11 @@ import * as MongoDriver from 'server/actions/MongoDriver'
 import * as apiValidator from 'utils/apiValidators'
 import { clientPromise } from '@api/auth/[...nextauth]'
 import constants from 'utils/constants'
-import { validItemDefinitionResponse, mockObjectId } from 'test/testData'
+import {
+  validItemDefinitionResponse,
+  mockObjectId,
+  validItemDefinitionPutRequest,
+} from 'test/testData'
 
 // TODO: add assertion for GET 'called with' aggregate stuff
 // this may need to have different functionality
@@ -115,7 +119,7 @@ describe('api/itemDefinitions/[itemDefinitionId]', () => {
         query: {
           itemDefinitionId: mockObjectId,
         },
-        body: validItemDefinitionResponse,
+        body: validItemDefinitionPutRequest,
       })
 
       const response = createResponse()
@@ -128,7 +132,7 @@ describe('api/itemDefinitions/[itemDefinitionId]', () => {
       expect(mockUpdateEntity).lastCalledWith(
         ItemDefinitionSchema,
         mockObjectId,
-        validItemDefinitionResponse
+        validItemDefinitionPutRequest
       )
       expect(response.statusCode).toBe(200)
       expect(data).toEqual({})

--- a/test/api/itemDefinitions/[itemDefinitionId].test.ts
+++ b/test/api/itemDefinitions/[itemDefinitionId].test.ts
@@ -4,7 +4,7 @@ import ItemDefinitionSchema, {
 } from 'server/models/ItemDefinition'
 import { ApiError, ItemDefinitionResponse } from 'utils/types'
 import { createRequest, createResponse } from 'node-mocks-http'
-import handler from 'pages/api/itemDefinitions/[itemDefinitionId]'
+import itemDefinitionHandler from 'pages/api/itemDefinitions/[itemDefinitionId]'
 import * as auth from 'utils/auth'
 import * as MongoDriver from 'server/actions/MongoDriver'
 import * as apiValidator from 'utils/apiValidators'
@@ -45,7 +45,7 @@ describe('api/itemDefinitions/[itemDefinitionId]', () => {
     })
     const response = createResponse()
 
-    await handler(request, response)
+    await itemDefinitionHandler(request, response)
 
     const data = response._getJSONData()
 
@@ -64,7 +64,7 @@ describe('api/itemDefinitions/[itemDefinitionId]', () => {
     })
     const response = createResponse()
 
-    await handler(request, response)
+    await itemDefinitionHandler(request, response)
 
     const data = response._getJSONData()
 
@@ -93,7 +93,7 @@ describe('api/itemDefinitions/[itemDefinitionId]', () => {
 
       const response = createResponse()
 
-      await handler(request, response)
+      await itemDefinitionHandler(request, response)
       const data = response._getJSONData().payload
 
       expect(mockGetEntity).toHaveBeenCalledTimes(1)
@@ -124,7 +124,7 @@ describe('api/itemDefinitions/[itemDefinitionId]', () => {
 
       const response = createResponse()
 
-      await handler(request, response)
+      await itemDefinitionHandler(request, response)
       const data = response._getJSONData().payload
 
       expect(mockApiItemDefinitionValidation).toHaveBeenCalledTimes(1)
@@ -154,7 +154,7 @@ describe('api/itemDefinitions/[itemDefinitionId]', () => {
       })
       const response = createResponse()
 
-      await handler(request, response)
+      await itemDefinitionHandler(request, response)
 
       expect(mockDeleteEntity).toHaveBeenCalledTimes(1)
       expect(mockDeleteEntity).lastCalledWith(

--- a/test/api/itemDefinitions/index.test.ts
+++ b/test/api/itemDefinitions/index.test.ts
@@ -2,7 +2,7 @@ import { ObjectId } from 'mongodb'
 import ItemDefinitionSchema, {
   ItemDefinitionDocument,
 } from 'server/models/ItemDefinition'
-import { ApiError, ItemDefinitionResponse } from 'utils/types'
+import { ApiError } from 'utils/types'
 import { createRequest, createResponse } from 'node-mocks-http'
 import handler from 'pages/api/itemDefinitions'
 import * as auth from 'utils/auth'
@@ -10,6 +10,7 @@ import * as MongoDriver from 'server/actions/MongoDriver'
 import * as apiValidator from 'utils/apiValidators'
 import { clientPromise } from '@api/auth/[...nextauth]'
 import constants from 'utils/constants'
+import { validItemDefinitionResponse, mockObjectId } from 'test/testData'
 
 beforeAll(() => {
   jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
@@ -114,14 +115,13 @@ describe('api/itemDefinitions', () => {
 
   describe('POST', () => {
     test('valid call returns correct data', async () => {
-      const fakeObjectId = '5f9f1c7b9c9b9b0b0c0c0c0c'
       const mockCreateEntity = jest
         .spyOn(MongoDriver, 'createEntity')
         .mockImplementation(
           async () =>
             ({
               ...validItemDefinitionResponse[0],
-              _id: fakeObjectId,
+              _id: mockObjectId,
             } as ItemDefinitionDocument & {
               _id: ObjectId
             })
@@ -133,7 +133,7 @@ describe('api/itemDefinitions', () => {
       const request = createRequest({
         method: 'POST',
         url: `/api/itemDefinitions`,
-        body: validItemDefinitionResponse[0],
+        body: validItemDefinitionResponse,
       })
 
       const response = createResponse()
@@ -145,31 +145,10 @@ describe('api/itemDefinitions', () => {
       expect(mockCreateEntity).toHaveBeenCalledTimes(1)
       expect(mockCreateEntity).lastCalledWith(
         ItemDefinitionSchema,
-        validItemDefinitionResponse[0]
+        validItemDefinitionResponse
       )
       expect(response.statusCode).toBe(201)
-      expect(data).toEqual(fakeObjectId)
+      expect(data).toEqual(mockObjectId)
     })
   })
 })
-const validItemDefinitionResponse: ItemDefinitionResponse[] = [
-  {
-    _id: '1',
-    name: 'Test Item',
-    internal: false,
-    lowStockThreshold: 10,
-    criticalStockThreshold: 5,
-    category: {
-      _id: '2',
-      name: 'Test Category',
-    },
-    attributes: [
-      {
-        _id: '3',
-        name: 'Test Attribute',
-        possibleValues: 'text',
-        color: '#000000',
-      },
-    ],
-  },
-]

--- a/test/api/itemDefinitions/index.test.ts
+++ b/test/api/itemDefinitions/index.test.ts
@@ -10,7 +10,11 @@ import * as MongoDriver from 'server/actions/MongoDriver'
 import * as apiValidator from 'utils/apiValidators'
 import { clientPromise } from '@api/auth/[...nextauth]'
 import constants from 'utils/constants'
-import { validItemDefinitionResponse, mockObjectId } from 'test/testData'
+import {
+  validItemDefinitionResponse,
+  mockObjectId,
+  validItemDefinitionPostRequest,
+} from 'test/testData'
 
 beforeAll(() => {
   jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
@@ -119,12 +123,9 @@ describe('api/itemDefinitions', () => {
         .spyOn(MongoDriver, 'createEntity')
         .mockImplementation(
           async () =>
-            ({
-              ...validItemDefinitionResponse[0],
-              _id: mockObjectId,
-            } as ItemDefinitionDocument & {
+            validItemDefinitionResponse[0] as ItemDefinitionDocument & {
               _id: ObjectId
-            })
+            }
         )
       const mockApiItemDefinitionValidation = jest
         .spyOn(apiValidator, 'apiItemDefinitionValidation')
@@ -133,7 +134,7 @@ describe('api/itemDefinitions', () => {
       const request = createRequest({
         method: 'POST',
         url: `/api/itemDefinitions`,
-        body: validItemDefinitionResponse[0],
+        body: validItemDefinitionPostRequest,
       })
 
       const response = createResponse()
@@ -145,7 +146,7 @@ describe('api/itemDefinitions', () => {
       expect(mockCreateEntity).toHaveBeenCalledTimes(1)
       expect(mockCreateEntity).lastCalledWith(
         ItemDefinitionSchema,
-        validItemDefinitionResponse[0]
+        validItemDefinitionPostRequest
       )
       expect(response.statusCode).toBe(201)
       expect(data).toEqual(mockObjectId)

--- a/test/api/itemDefinitions/index.test.ts
+++ b/test/api/itemDefinitions/index.test.ts
@@ -133,7 +133,7 @@ describe('api/itemDefinitions', () => {
       const request = createRequest({
         method: 'POST',
         url: `/api/itemDefinitions`,
-        body: validItemDefinitionResponse,
+        body: validItemDefinitionResponse[0],
       })
 
       const response = createResponse()
@@ -145,7 +145,7 @@ describe('api/itemDefinitions', () => {
       expect(mockCreateEntity).toHaveBeenCalledTimes(1)
       expect(mockCreateEntity).lastCalledWith(
         ItemDefinitionSchema,
-        validItemDefinitionResponse
+        validItemDefinitionResponse[0]
       )
       expect(response.statusCode).toBe(201)
       expect(data).toEqual(mockObjectId)

--- a/test/api/itemDefinitions/index.test.ts
+++ b/test/api/itemDefinitions/index.test.ts
@@ -4,7 +4,7 @@ import ItemDefinitionSchema, {
 } from 'server/models/ItemDefinition'
 import { ApiError } from 'utils/types'
 import { createRequest, createResponse } from 'node-mocks-http'
-import handler from 'pages/api/itemDefinitions'
+import itemDefinitionsHandler from 'pages/api/itemDefinitions'
 import * as auth from 'utils/auth'
 import * as MongoDriver from 'server/actions/MongoDriver'
 import * as apiValidator from 'utils/apiValidators'
@@ -42,7 +42,7 @@ describe('api/itemDefinitions', () => {
     })
     const response = createResponse()
 
-    await handler(request, response)
+    await itemDefinitionsHandler(request, response)
 
     const data = response._getJSONData()
 
@@ -58,7 +58,7 @@ describe('api/itemDefinitions', () => {
     })
     const response = createResponse()
 
-    await handler(request, response)
+    await itemDefinitionsHandler(request, response)
 
     const data = response._getJSONData()
 
@@ -87,7 +87,7 @@ describe('api/itemDefinitions', () => {
 
       const response = createResponse()
 
-      await handler(request, response)
+      await itemDefinitionsHandler(request, response)
       const data = response._getJSONData().payload
 
       expect(serverAuth).toHaveBeenCalledTimes(1)
@@ -108,7 +108,7 @@ describe('api/itemDefinitions', () => {
 
       const response = createResponse()
 
-      await handler(request, response)
+      await itemDefinitionsHandler(request, response)
       const data = response._getJSONData().payload
 
       expect(mockGetEntities).toHaveBeenCalledTimes(1)
@@ -139,7 +139,7 @@ describe('api/itemDefinitions', () => {
 
       const response = createResponse()
 
-      await handler(request, response)
+      await itemDefinitionsHandler(request, response)
       const data = response._getJSONData().payload
 
       expect(mockApiItemDefinitionValidation).toHaveBeenCalledTimes(1)

--- a/test/api/users/[userId].test.ts
+++ b/test/api/users/[userId].test.ts
@@ -1,6 +1,6 @@
 import { ObjectId } from 'mongodb'
 import UserSchema, { UserDocument } from 'server/models/User'
-import { ApiError, UserResponse } from 'utils/types'
+import { ApiError } from 'utils/types'
 import { createRequest, createResponse } from 'node-mocks-http'
 import handler from 'pages/api/users/[userId]'
 import * as auth from 'utils/auth'
@@ -9,6 +9,7 @@ import * as apiValidator from 'utils/apiValidators'
 import mongoose from 'mongoose'
 import { clientPromise } from '@api/auth/[...nextauth]'
 import constants from 'utils/constants'
+import { validUserResponse, mockObjectId } from 'test/testData'
 
 beforeAll(() => {
   jest.spyOn(apiValidator, 'apiObjectIdValidation').mockImplementation()
@@ -18,7 +19,7 @@ beforeAll(() => {
   jest
     .spyOn(MongoDriver, 'getEntity')
     .mockImplementation(
-      async () => validUserResponse as UserDocument & { _id: ObjectId }
+      async () => validUserResponse[0] as UserDocument & { _id: ObjectId }
     )
 })
 
@@ -43,9 +44,9 @@ describe('api/users/[userId]', () => {
 
     const request = createRequest({
       method: 'GET',
-      url: `/api/users/${fakeObjectId}`,
+      url: `/api/users/${mockObjectId}`,
       query: {
-        userId: fakeObjectId,
+        userId: mockObjectId,
       },
     })
     const response = createResponse()
@@ -62,9 +63,9 @@ describe('api/users/[userId]', () => {
   test('unsupported method returns 405', async () => {
     const request = createRequest({
       method: 'POST',
-      url: `/api/users/${fakeObjectId}`,
+      url: `/api/users/${mockObjectId}`,
       query: {
-        userId: fakeObjectId,
+        userId: mockObjectId,
       },
     })
     const response = createResponse()
@@ -83,14 +84,14 @@ describe('api/users/[userId]', () => {
       const mockGetEntity = jest
         .spyOn(MongoDriver, 'getEntity')
         .mockImplementation(
-          async () => validUserResponse as UserDocument & { _id: ObjectId }
+          async () => validUserResponse[0] as UserDocument & { _id: ObjectId }
         )
 
       const request = createRequest({
         method: 'GET',
-        url: `/api/users/${fakeObjectId}`,
+        url: `/api/users/${mockObjectId}`,
         query: {
-          userId: fakeObjectId,
+          userId: mockObjectId,
         },
       })
 
@@ -100,9 +101,9 @@ describe('api/users/[userId]', () => {
       const data = response._getJSONData().payload
 
       expect(mockGetEntity).toHaveBeenCalledTimes(1)
-      expect(mockGetEntity).lastCalledWith(UserSchema, fakeObjectId)
+      expect(mockGetEntity).lastCalledWith(UserSchema, mockObjectId)
       expect(response.statusCode).toBe(200)
-      expect(data).toEqual(validUserResponse)
+      expect(data).toEqual(validUserResponse[0])
     })
   })
 
@@ -119,9 +120,9 @@ describe('api/users/[userId]', () => {
 
       const request = createRequest({
         method: 'PUT',
-        url: `/api/users/${fakeObjectId}`,
+        url: `/api/users/${mockObjectId}`,
         query: {
-          userId: fakeObjectId,
+          userId: mockObjectId,
         },
         body: validUserResponse,
       })
@@ -135,7 +136,7 @@ describe('api/users/[userId]', () => {
       expect(mockUpdateEntity).toHaveBeenCalledTimes(1)
       expect(mockUpdateEntity).lastCalledWith(
         UserSchema,
-        fakeObjectId,
+        mockObjectId,
         validUserResponse
       )
       expect(response.statusCode).toBe(200)
@@ -151,9 +152,9 @@ describe('api/users/[userId]', () => {
         .mockImplementation(async () => {})
       const request = createRequest({
         method: 'DELETE',
-        url: `/api/users/${fakeObjectId}`,
+        url: `/api/users/${mockObjectId}`,
         query: {
-          userId: fakeObjectId,
+          userId: mockObjectId,
         },
       })
       const response = createResponse()
@@ -161,16 +162,9 @@ describe('api/users/[userId]', () => {
       await handler(request, response)
 
       expect(mockDeleteEntity).toHaveBeenCalledTimes(1)
-      expect(mockDeleteEntity).lastCalledWith(UserSchema, fakeObjectId)
+      expect(mockDeleteEntity).lastCalledWith(UserSchema, mockObjectId)
       expect(response.statusCode).toBe(200)
       expect(response._getJSONData().payload).toEqual({})
     })
   })
 })
-const validUserResponse: UserResponse = {
-  _id: '1',
-  name: 'Test User',
-  email: 'test@user.com',
-  image: 'https://test.com/image.jpg',
-}
-const fakeObjectId = '6408a7156668c5655c25b105'

--- a/test/api/users/[userId].test.ts
+++ b/test/api/users/[userId].test.ts
@@ -2,7 +2,7 @@ import { ObjectId } from 'mongodb'
 import UserSchema, { UserDocument } from 'server/models/User'
 import { ApiError } from 'utils/types'
 import { createRequest, createResponse } from 'node-mocks-http'
-import handler from 'pages/api/users/[userId]'
+import userHandler from 'pages/api/users/[userId]'
 import * as auth from 'utils/auth'
 import * as MongoDriver from 'server/actions/MongoDriver'
 import * as apiValidator from 'utils/apiValidators'
@@ -55,7 +55,7 @@ describe('api/users/[userId]', () => {
     })
     const response = createResponse()
 
-    await handler(request, response)
+    await userHandler(request, response)
 
     const data = response._getJSONData()
 
@@ -74,7 +74,7 @@ describe('api/users/[userId]', () => {
     })
     const response = createResponse()
 
-    await handler(request, response)
+    await userHandler(request, response)
 
     const data = response._getJSONData()
 
@@ -101,7 +101,7 @@ describe('api/users/[userId]', () => {
 
       const response = createResponse()
 
-      await handler(request, response)
+      await userHandler(request, response)
       const data = response._getJSONData().payload
 
       expect(mockGetEntity).toHaveBeenCalledTimes(1)
@@ -133,7 +133,7 @@ describe('api/users/[userId]', () => {
 
       const response = createResponse()
 
-      await handler(request, response)
+      await userHandler(request, response)
       const data = response._getJSONData().payload
 
       expect(mockApiUserValidation).toHaveBeenCalledTimes(1)
@@ -163,7 +163,7 @@ describe('api/users/[userId]', () => {
       })
       const response = createResponse()
 
-      await handler(request, response)
+      await userHandler(request, response)
 
       expect(mockDeleteEntity).toHaveBeenCalledTimes(1)
       expect(mockDeleteEntity).lastCalledWith(UserSchema, mockObjectId)

--- a/test/api/users/[userId].test.ts
+++ b/test/api/users/[userId].test.ts
@@ -9,7 +9,11 @@ import * as apiValidator from 'utils/apiValidators'
 import mongoose from 'mongoose'
 import { clientPromise } from '@api/auth/[...nextauth]'
 import constants from 'utils/constants'
-import { validUserResponse, mockObjectId } from 'test/testData'
+import {
+  validUserResponse,
+  mockObjectId,
+  validUserPutRequest,
+} from 'test/testData'
 
 beforeAll(() => {
   jest.spyOn(apiValidator, 'apiObjectIdValidation').mockImplementation()
@@ -124,7 +128,7 @@ describe('api/users/[userId]', () => {
         query: {
           userId: mockObjectId,
         },
-        body: validUserResponse,
+        body: validUserPutRequest,
       })
 
       const response = createResponse()
@@ -137,7 +141,7 @@ describe('api/users/[userId]', () => {
       expect(mockUpdateEntity).lastCalledWith(
         UserSchema,
         mockObjectId,
-        validUserResponse
+        validUserPutRequest
       )
       expect(response.statusCode).toBe(200)
       expect(data).toEqual({})

--- a/test/api/users/index.test.ts
+++ b/test/api/users/index.test.ts
@@ -2,7 +2,7 @@ import { ObjectId } from 'mongodb'
 import UserSchema, { UserDocument } from 'server/models/User'
 import { ApiError } from 'utils/types'
 import { createRequest, createResponse } from 'node-mocks-http'
-import handler from 'pages/api/users'
+import usersHandler from 'pages/api/users'
 import * as auth from 'utils/auth'
 import * as MongoDriver from 'server/actions/MongoDriver'
 import * as apiValidator from 'utils/apiValidators'
@@ -42,7 +42,7 @@ describe('api/users', () => {
     })
     const response = createResponse()
 
-    await handler(request, response)
+    await usersHandler(request, response)
 
     const data = response._getJSONData()
 
@@ -58,7 +58,7 @@ describe('api/users', () => {
     })
     const response = createResponse()
 
-    await handler(request, response)
+    await usersHandler(request, response)
 
     const data = response._getJSONData()
 
@@ -84,7 +84,7 @@ describe('api/users', () => {
 
       const response = createResponse()
 
-      await handler(request, response)
+      await usersHandler(request, response)
       const data = response._getJSONData().payload
 
       expect(serverAuth).toHaveBeenCalledTimes(1)
@@ -106,7 +106,7 @@ describe('api/users', () => {
 
       const response = createResponse()
 
-      await handler(request, response)
+      await usersHandler(request, response)
       const data = response._getJSONData().payload
 
       expect(mockGetEntities).toHaveBeenCalledTimes(1)
@@ -135,7 +135,7 @@ describe('api/users', () => {
 
       const response = createResponse()
 
-      await handler(request, response)
+      await usersHandler(request, response)
       const data = response._getJSONData().payload
 
       expect(mockApiUserValidation).toHaveBeenCalledTimes(1)

--- a/test/api/users/index.test.ts
+++ b/test/api/users/index.test.ts
@@ -9,7 +9,11 @@ import * as apiValidator from 'utils/apiValidators'
 import mongoose from 'mongoose'
 import { clientPromise } from '@api/auth/[...nextauth]'
 import constants from 'utils/constants'
-import { validUserResponse, mockObjectId } from 'test/testData'
+import {
+  validUserResponse,
+  mockObjectId,
+  validUserPostRequest,
+} from 'test/testData'
 
 beforeAll(() => {
   jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
@@ -117,13 +121,7 @@ describe('api/users', () => {
       const mockCreateEntity = jest
         .spyOn(MongoDriver, 'createEntity')
         .mockImplementation(
-          async () =>
-            ({
-              ...validUserResponse[0],
-              _id: mockObjectId,
-            } as UserDocument & {
-              _id: ObjectId
-            })
+          async () => validUserResponse[0] as UserDocument & { _id: ObjectId }
         )
       const mockApiUserValidation = jest
         .spyOn(apiValidator, 'apiUserValidation')
@@ -132,7 +130,7 @@ describe('api/users', () => {
       const request = createRequest({
         method: 'POST',
         url: `/api/users`,
-        body: validUserResponse[0],
+        body: validUserPostRequest,
       })
 
       const response = createResponse()
@@ -142,7 +140,7 @@ describe('api/users', () => {
 
       expect(mockApiUserValidation).toHaveBeenCalledTimes(1)
       expect(mockCreateEntity).toHaveBeenCalledTimes(1)
-      expect(mockCreateEntity).lastCalledWith(UserSchema, validUserResponse[0])
+      expect(mockCreateEntity).lastCalledWith(UserSchema, validUserPostRequest)
       expect(response.statusCode).toBe(201)
       expect(data).toEqual(mockObjectId)
     })

--- a/test/api/users/index.test.ts
+++ b/test/api/users/index.test.ts
@@ -1,6 +1,6 @@
 import { ObjectId } from 'mongodb'
 import UserSchema, { UserDocument } from 'server/models/User'
-import { ApiError, UserResponse } from 'utils/types'
+import { ApiError } from 'utils/types'
 import { createRequest, createResponse } from 'node-mocks-http'
 import handler from 'pages/api/users'
 import * as auth from 'utils/auth'
@@ -9,6 +9,7 @@ import * as apiValidator from 'utils/apiValidators'
 import mongoose from 'mongoose'
 import { clientPromise } from '@api/auth/[...nextauth]'
 import constants from 'utils/constants'
+import { validUserResponse, mockObjectId } from 'test/testData'
 
 beforeAll(() => {
   jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
@@ -113,14 +114,13 @@ describe('api/users', () => {
 
   describe('POST', () => {
     test('valid call returns correct data', async () => {
-      const fakeObjectId = '5f9f1c7b9c9b9b0b0c0c0c0c'
       const mockCreateEntity = jest
         .spyOn(MongoDriver, 'createEntity')
         .mockImplementation(
           async () =>
             ({
               ...validUserResponse[0],
-              _id: fakeObjectId,
+              _id: mockObjectId,
             } as UserDocument & {
               _id: ObjectId
             })
@@ -144,15 +144,7 @@ describe('api/users', () => {
       expect(mockCreateEntity).toHaveBeenCalledTimes(1)
       expect(mockCreateEntity).lastCalledWith(UserSchema, validUserResponse[0])
       expect(response.statusCode).toBe(201)
-      expect(data).toEqual(fakeObjectId)
+      expect(data).toEqual(mockObjectId)
     })
   })
 })
-const validUserResponse: UserResponse[] = [
-  {
-    _id: '1',
-    email: 'test@user.com',
-    name: 'Test User',
-    image: 'https://test.com/image.png',
-  },
-]

--- a/test/server/MongoDriver.test.ts
+++ b/test/server/MongoDriver.test.ts
@@ -4,6 +4,7 @@ import { ApiError } from 'utils/types'
 import mongoose from 'mongoose'
 import { clientPromise } from '@api/auth/[...nextauth]'
 import constants from 'utils/constants'
+import { validCategoryResponse, mockObjectId } from 'test/testData'
 
 // restore mocked implementations and close db connections
 afterAll(() => {
@@ -18,7 +19,7 @@ describe('MongoDriver', () => {
       const findByIdSpy = jest.spyOn(CategorySchema, 'findById')
       const mockAggregate = (CategorySchema.aggregate = jest
         .fn()
-        .mockImplementation(async () => [categoryFixture]))
+        .mockImplementation(async () => [validCategoryResponse]))
 
       const category = await MongoDriver.getEntity(
         CategorySchema,
@@ -28,7 +29,7 @@ describe('MongoDriver', () => {
 
       expect(findByIdSpy).toHaveBeenCalledTimes(0)
       expect(mockAggregate).toHaveBeenCalledTimes(1)
-      expect(category).toEqual(categoryFixture)
+      expect(category).toEqual(validCategoryResponse)
     })
 
     test('aggregate only returns one object', async () => {
@@ -36,8 +37,8 @@ describe('MongoDriver', () => {
       const mockAggregate = (CategorySchema.aggregate = jest
         .fn()
         .mockImplementation(async () => [
-          categoryFixture,
-          { ...categoryFixture, _id: '123' },
+          validCategoryResponse,
+          { ...validCategoryResponse, _id: '123' },
         ]))
 
       const category = await MongoDriver.getEntity(
@@ -48,18 +49,18 @@ describe('MongoDriver', () => {
 
       expect(findByIdSpy).toHaveBeenCalledTimes(0)
       expect(mockAggregate).toHaveBeenCalledTimes(1)
-      expect(category).toEqual(categoryFixture)
+      expect(category).toEqual(validCategoryResponse)
     })
     test('valid call returns correct data', async () => {
       const mockFindById = (CategorySchema.findById = jest
         .fn()
-        .mockImplementation(async () => categoryFixture))
+        .mockImplementation(async () => validCategoryResponse))
 
       const category = await MongoDriver.getEntity(CategorySchema, mockObjectId)
 
       expect(mockFindById).toHaveBeenCalledTimes(1)
       expect(mockFindById).lastCalledWith(mockObjectId)
-      expect(category).toEqual(categoryFixture)
+      expect(category).toEqual(validCategoryResponse)
     })
 
     test('entity not found returns 404', async () => {
@@ -83,7 +84,7 @@ describe('MongoDriver', () => {
       const findByIdSpy = jest.spyOn(CategorySchema, 'find')
       const mockAggregate = (CategorySchema.aggregate = jest
         .fn()
-        .mockImplementation(async () => [categoryFixture]))
+        .mockImplementation(async () => [validCategoryResponse]))
 
       const category = await MongoDriver.getEntities(CategorySchema, [
         { $match: { _id: mockObjectId } },
@@ -92,17 +93,17 @@ describe('MongoDriver', () => {
 
       expect(findByIdSpy).toHaveBeenCalledTimes(0)
       expect(mockAggregate).toHaveBeenCalledTimes(1)
-      expect(category).toEqual([categoryFixture])
+      expect(category).toEqual([validCategoryResponse])
     })
     test('valid call returns correct data', async () => {
       const mockFind = (CategorySchema.find = jest
         .fn()
-        .mockImplementation(async () => [categoryFixture]))
+        .mockImplementation(async () => [validCategoryResponse]))
 
       const categories = await MongoDriver.getEntities(CategorySchema)
 
       expect(mockFind).toHaveBeenCalledTimes(1)
-      expect(categories).toEqual([categoryFixture])
+      expect(categories).toEqual([validCategoryResponse])
     })
   })
 
@@ -110,15 +111,15 @@ describe('MongoDriver', () => {
     test('returns entity', async () => {
       const mockCreate = (CategorySchema.create = jest
         .fn()
-        .mockImplementation(async () => categoryFixture))
+        .mockImplementation(async () => validCategoryResponse))
 
       const category = await MongoDriver.createEntity(CategorySchema, {
-        ...categoryFixture,
+        ...validCategoryResponse[0],
         _id: undefined,
       })
 
       expect(mockCreate).toHaveBeenCalledTimes(1)
-      expect(category).toEqual(categoryFixture)
+      expect(category).toEqual(validCategoryResponse)
     })
   })
 
@@ -126,11 +127,11 @@ describe('MongoDriver', () => {
     test('valid id calls findByIdAndUpdate', async () => {
       const mockUpdate = (CategorySchema.findByIdAndUpdate = jest
         .fn()
-        .mockImplementation(async () => categoryFixture))
+        .mockImplementation(async () => validCategoryResponse))
       await MongoDriver.updateEntity(
         CategorySchema,
         mockObjectId,
-        categoryFixture
+        validCategoryResponse[0]
       )
 
       expect(mockUpdate).toHaveBeenCalledTimes(1)
@@ -146,7 +147,7 @@ describe('MongoDriver', () => {
         await MongoDriver.updateEntity(
           CategorySchema,
           mockObjectId,
-          categoryFixture
+          validCategoryResponse[0]
         )
       } catch (error) {
         expect(mockUpdate).toHaveBeenCalledTimes(1)
@@ -161,7 +162,7 @@ describe('MongoDriver', () => {
     test('valid id calls findByIdAndDelete', async () => {
       const mockDelete = (CategorySchema.findByIdAndDelete = jest
         .fn()
-        .mockImplementation(async () => categoryFixture))
+        .mockImplementation(async () => validCategoryResponse))
       await MongoDriver.deleteEntity(CategorySchema, mockObjectId)
 
       expect(mockDelete).toHaveBeenCalledTimes(1)
@@ -188,21 +189,14 @@ describe('MongoDriver', () => {
     test('valid call returns correct data', async () => {
       const mockFind = (CategorySchema.find = jest
         .fn()
-        .mockImplementation(async () => [categoryFixture]))
+        .mockImplementation(async () => [validCategoryResponse]))
 
       const categories = await MongoDriver.findEntities(CategorySchema, {
         name: 'test',
       })
 
       expect(mockFind).toHaveBeenCalledTimes(1)
-      expect(categories).toEqual([categoryFixture])
+      expect(categories).toEqual([validCategoryResponse])
     })
   })
 })
-
-const mockObjectId = '6408a7156668c5655c25b105'
-
-const categoryFixture = {
-  _id: mockObjectId,
-  name: 'test',
-}

--- a/test/testData.ts
+++ b/test/testData.ts
@@ -1,0 +1,61 @@
+import {
+  AttributeResponse,
+  CategoryResponse,
+  InventoryItemResponse,
+  ItemDefinitionResponse,
+  UserResponse,
+} from 'utils/types'
+
+export const mockObjectId = '6408a7156668c5655c25b105'
+
+export const validAttributeResponse: AttributeResponse[] = [
+  {
+    _id: '1',
+    name: 'test',
+    possibleValues: 'text',
+    color: '#000000',
+  },
+]
+
+export const validCategoryResponse: CategoryResponse[] = [
+  {
+    _id: '1',
+    name: 'test',
+  },
+]
+
+export const validItemDefinitionResponse: ItemDefinitionResponse[] = [
+  {
+    _id: '1',
+    name: 'Test Item',
+    internal: false,
+    lowStockThreshold: 10,
+    criticalStockThreshold: 5,
+    category: validCategoryResponse[0],
+    attributes: validAttributeResponse,
+  },
+]
+
+export const validUserResponse: UserResponse[] = [
+  {
+    _id: '1',
+    name: 'Test User',
+    email: 'test@user.com',
+    image: 'https://test.com/image.jpg',
+  },
+]
+
+export const validInventoryItemResponse: InventoryItemResponse[] = [
+  {
+    _id: '1',
+    itemDefinition: validItemDefinitionResponse[0],
+    quantity: 10,
+    attributes: [
+      {
+        attribute: validAttributeResponse[0],
+        value: 'val',
+      },
+    ],
+    assignee: validUserResponse[0],
+  },
+]

--- a/test/testData.ts
+++ b/test/testData.ts
@@ -1,43 +1,58 @@
 import {
-  AttributeRequest,
+  AttributePostRequest,
+  AttributePutRequest,
   AttributeResponse,
-  CategoryRequest,
+  CategoryPostRequest,
+  CategoryPutRequest,
   CategoryResponse,
-  InventoryItemRequest,
-  InventoryItemResponse,
-  ItemDefinitionRequest,
+  ItemDefinitionPostRequest,
+  ItemDefinitionPutRequest,
   ItemDefinitionResponse,
-  UserRequest,
+  UserPostRequest,
+  UserPutRequest,
   UserResponse,
+  InventoryItemPostRequest,
+  InventoryItemPutRequest,
+  InventoryItemResponse,
 } from 'utils/types'
 
 export const mockObjectId = '6408a7156668c5655c25b105'
 
-export const validAttributeRequest: AttributeRequest = {
+export const validAttributePostRequest: AttributePostRequest = {
   name: 'test',
   possibleValues: 'text',
   color: '#000000',
 }
 
+export const validAttributePutRequest: AttributePutRequest = {
+  ...validAttributePostRequest,
+  _id: mockObjectId,
+}
+
 export const validAttributeResponse: AttributeResponse[] = [
   {
-    ...validAttributeRequest,
-    _id: '1',
+    ...validAttributePostRequest,
+    _id: mockObjectId,
   },
 ]
 
-export const validCategoryRequest: CategoryRequest = {
+export const validCategoryPostRequest: CategoryPostRequest = {
   name: 'test',
+}
+
+export const validCategoryPutRequest: CategoryPutRequest = {
+  ...validCategoryPostRequest,
+  _id: mockObjectId,
 }
 
 export const validCategoryResponse: CategoryResponse[] = [
   {
-    ...validCategoryRequest,
-    _id: '1',
+    ...validCategoryPostRequest,
+    _id: mockObjectId,
   },
 ]
 
-export const validItemDefinitionRequest: ItemDefinitionRequest = {
+export const validItemDefinitionPostRequest: ItemDefinitionPostRequest = {
   name: 'Test Item',
   internal: false,
   lowStockThreshold: 10,
@@ -46,30 +61,40 @@ export const validItemDefinitionRequest: ItemDefinitionRequest = {
   attributes: [validAttributeResponse[0]._id],
 }
 
+export const validItemDefinitionPutRequest: ItemDefinitionPutRequest = {
+  ...validItemDefinitionPostRequest,
+  _id: mockObjectId,
+}
+
 export const validItemDefinitionResponse: ItemDefinitionResponse[] = [
   {
-    ...validItemDefinitionRequest,
-    _id: '1',
+    ...validItemDefinitionPostRequest,
+    _id: mockObjectId,
     category: validCategoryResponse[0],
     attributes: validAttributeResponse,
   },
 ]
 
-export const validUserRequest: UserRequest = {
+export const validUserPostRequest: UserPostRequest = {
   name: 'Test User',
   email: 'test@user.com',
   image: 'https://test.com/image.jpg',
 }
 
+export const validUserPutRequest: UserPutRequest = {
+  ...validUserPostRequest,
+  _id: mockObjectId,
+}
+
 export const validUserResponse: UserResponse[] = [
   {
-    ...validUserRequest,
-    _id: '1',
+    ...validUserPostRequest,
+    _id: mockObjectId,
   },
 ]
 
-export const validInventoryItemRequest: InventoryItemRequest = {
-  _id: '1',
+export const validInventoryItemPostRequest: InventoryItemPostRequest = {
+  _id: mockObjectId,
   itemDefinition: validItemDefinitionResponse[0]._id,
   quantity: 10,
   attributes: [
@@ -81,9 +106,14 @@ export const validInventoryItemRequest: InventoryItemRequest = {
   assignee: validUserResponse[0]._id,
 }
 
+export const validInventoryItemPutRequest: InventoryItemPutRequest = {
+  ...validInventoryItemPostRequest,
+  _id: mockObjectId,
+}
+
 export const validInventoryItemResponse: InventoryItemResponse[] = [
   {
-    _id: '1',
+    _id: mockObjectId,
     itemDefinition: validItemDefinitionResponse[0],
     quantity: 10,
     attributes: [

--- a/test/testData.ts
+++ b/test/testData.ts
@@ -1,49 +1,85 @@
 import {
+  AttributeRequest,
   AttributeResponse,
+  CategoryRequest,
   CategoryResponse,
+  InventoryItemRequest,
   InventoryItemResponse,
+  ItemDefinitionRequest,
   ItemDefinitionResponse,
+  UserRequest,
   UserResponse,
 } from 'utils/types'
 
 export const mockObjectId = '6408a7156668c5655c25b105'
 
+export const validAttributeRequest: AttributeRequest = {
+  name: 'test',
+  possibleValues: 'text',
+  color: '#000000',
+}
+
 export const validAttributeResponse: AttributeResponse[] = [
   {
+    ...validAttributeRequest,
     _id: '1',
-    name: 'test',
-    possibleValues: 'text',
-    color: '#000000',
   },
 ]
+
+export const validCategoryRequest: CategoryRequest = {
+  name: 'test',
+}
 
 export const validCategoryResponse: CategoryResponse[] = [
   {
+    ...validCategoryRequest,
     _id: '1',
-    name: 'test',
   },
 ]
 
+export const validItemDefinitionRequest: ItemDefinitionRequest = {
+  name: 'Test Item',
+  internal: false,
+  lowStockThreshold: 10,
+  criticalStockThreshold: 5,
+  category: validCategoryResponse[0]._id,
+  attributes: [validAttributeResponse[0]._id],
+}
+
 export const validItemDefinitionResponse: ItemDefinitionResponse[] = [
   {
+    ...validItemDefinitionRequest,
     _id: '1',
-    name: 'Test Item',
-    internal: false,
-    lowStockThreshold: 10,
-    criticalStockThreshold: 5,
     category: validCategoryResponse[0],
     attributes: validAttributeResponse,
   },
 ]
 
+export const validUserRequest: UserRequest = {
+  name: 'Test User',
+  email: 'test@user.com',
+  image: 'https://test.com/image.jpg',
+}
+
 export const validUserResponse: UserResponse[] = [
   {
+    ...validUserRequest,
     _id: '1',
-    name: 'Test User',
-    email: 'test@user.com',
-    image: 'https://test.com/image.jpg',
   },
 ]
+
+export const validInventoryItemRequest: InventoryItemRequest = {
+  _id: '1',
+  itemDefinition: validItemDefinitionResponse[0]._id,
+  quantity: 10,
+  attributes: [
+    {
+      attribute: validAttributeResponse[0]._id,
+      value: 'val',
+    },
+  ],
+  assignee: validUserResponse[0]._id,
+}
 
 export const validInventoryItemResponse: InventoryItemResponse[] = [
   {

--- a/utils/types/requests.ts
+++ b/utils/types/requests.ts
@@ -29,6 +29,7 @@ export interface InventoryItemAttributeRequest {
 export interface InventoryItemRequest extends InventoryItem {
   itemDefinition: string
   attributes?: InventoryItemAttributeRequest[]
+  assignee?: string
 }
 
 export type CategoryPostRequest = Omit<Category, '_id'>

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -240,7 +240,7 @@ export const inventoryItemRequestModelProperties: Property[] = [
   {
     key: 'assignee',
     types: 'string',
-    required: true,
+    required: false,
   },
 ]
 


### PR DESCRIPTION
This PR fulfills [CCAHT-56](https://team-16679321250140.atlassian.net/jira/software/projects/CCAHT/boards/1?selectedIssue=CCAHT-56), putting the InventoryItemList component on the Inventory page.

In the process, I also make the CRUD api endpoints/server funcs for inventoryItems. Added a few TODOs for some tech-debt to cover in the future.

Also renamed API handlers to be more descriptive, since we'll be calling them directly in the future.

In writing the tests, I created `testData.ts`, which hosts all of our test data so we don't have hard-coded constants

[CCAHT-56]: https://team-16679321250140.atlassian.net/browse/CCAHT-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ