### PR TITLE
CCAHT-105 add snackbar service and update existing calls to use it

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
   "rules": {
     // I suggest you add those two rules:
     "@typescript-eslint/no-unused-vars": "error",
-    "@typescript-eslint/no-explicit-any": "error"
+    "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/ban-ts-comment": "off"
   }
 }

--- a/components/DefaultLayout/index.tsx
+++ b/components/DefaultLayout/index.tsx
@@ -14,11 +14,18 @@ export default function DefaultLayout({ children }: DefaultLayoutProps) {
   const dispatch = useAppDispatch();
   const snackbar = useAppSelector((state) => state.snackbar)
 
-  const handleClose = (event?: React.SyntheticEvent | Event, reason?: string) => {
+  React.useEffect(() => {
+    // @ts-ignore
+    dispatch(clearSnackbar())
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [children])
+
+  const handleClose = (_e?: React.SyntheticEvent | Event, reason?: string) => {
     if (reason === 'clickaway') {
       return;
     }
 
+    // @ts-ignore
     dispatch(clearSnackbar());
   };
   return (
@@ -32,13 +39,13 @@ export default function DefaultLayout({ children }: DefaultLayoutProps) {
         <NavigationDrawer setDrawerOpen={setDrawerOpen} open={drawerOpen} />
         <Box component="main" sx={{ flexGrow: 1 }}>
           {children}
+          <Snackbar key={snackbar.message} open={snackbar.open} autoHideDuration={10000} onClose={handleClose} sx={{ mt: 8}} anchorOrigin={{vertical: "top", horizontal: "right"}} >
+            <Alert onClose={handleClose} severity={snackbar.severity} sx={{ width: '100%' }} elevation={8}>
+              {snackbar.message}
+            </Alert>
+          </Snackbar>
         </Box>
       </Box>
-      <Snackbar open={snackbar.open} autoHideDuration={10000} onClose={handleClose} anchorOrigin={{vertical: "bottom", horizontal: "right"}} >
-        <Alert onClose={handleClose} severity={snackbar.severity} sx={{ width: '100%' }}>
-          {snackbar.message}
-        </Alert>
-      </Snackbar>
     </>
   )
 }

--- a/components/DefaultLayout/index.tsx
+++ b/components/DefaultLayout/index.tsx
@@ -2,12 +2,25 @@ import React from 'react'
 import NavigationDrawer from 'components/NavigationDrawer'
 import HeaderAppBar from 'components/HeaderAppBar'
 import Box from '@mui/material/Box'
+import { useAppDispatch, useAppSelector } from 'store'
+import { clearSnackbar } from 'store/snackbar'
+import { Alert, Snackbar } from '@mui/material'
 interface DefaultLayoutProps {
   children: React.ReactNode
 }
 
 export default function DefaultLayout({ children }: DefaultLayoutProps) {
   const [drawerOpen, setDrawerOpen] = React.useState(false)
+  const dispatch = useAppDispatch();
+  const snackbar = useAppSelector((state) => state.snackbar)
+
+  const handleClose = (event?: React.SyntheticEvent | Event, reason?: string) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+
+    dispatch(clearSnackbar());
+  };
   return (
     <>
       <HeaderAppBar setDrawerOpen={setDrawerOpen} />
@@ -21,6 +34,11 @@ export default function DefaultLayout({ children }: DefaultLayoutProps) {
           {children}
         </Box>
       </Box>
+      <Snackbar open={snackbar.open} autoHideDuration={10000} onClose={handleClose} anchorOrigin={{vertical: "bottom", horizontal: "right"}} >
+        <Alert onClose={handleClose} severity={snackbar.severity} sx={{ width: '100%' }}>
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
     </>
   )
 }

--- a/components/InventoryItemListItemKebab/index.tsx
+++ b/components/InventoryItemListItemKebab/index.tsx
@@ -4,6 +4,8 @@ import React from 'react'
 import theme from 'utils/theme'
 import { InventoryItem } from 'utils/types'
 import { useRouter } from 'next/router'
+import { showSnackbar } from 'store/snackbar'
+import { useAppDispatch } from 'store'
 
 interface InventoryItemListItemKebabOption {
   name: string
@@ -30,6 +32,7 @@ export default function InventoryItemListItemKebab({
     setAnchorElKebab(null)
   }
   const router = useRouter()
+  const dispatch = useAppDispatch()
   const option: InventoryItemListItemKebabOption[] = [
     {
       name: 'Check in',
@@ -57,6 +60,7 @@ export default function InventoryItemListItemKebab({
           method: 'DELETE',
         }).then(() => {
           window.location.reload()
+          dispatch(showSnackbar({message: "Item successfully deleted.", severity: "success"}))
         })
       }},
     },

--- a/components/InventoryItemListItemKebab/index.tsx
+++ b/components/InventoryItemListItemKebab/index.tsx
@@ -60,6 +60,7 @@ export default function InventoryItemListItemKebab({
           method: 'DELETE',
         }).then(() => {
           window.location.reload()
+          // @ts-ignore
           dispatch(showSnackbar({message: "Item successfully deleted.", severity: "success"}))
         })
       }},

--- a/pages/checkIn.tsx
+++ b/pages/checkIn.tsx
@@ -84,8 +84,12 @@ export default function CheckInPage({
     const data = await response.json()
 
     if (data.success) {
-      dispatch(showSnackbar({message: "Item successfully checked out.", severity: "success"}))
+      // @ts-ignore
+      // @ts-ignore
+      dispatch(showSnackbar({message: "Item successfully checked in.", severity: "success"}))
     } else {
+      // @ts-ignore
+      // @ts-ignore
       dispatch(showSnackbar({message: data.message, severity: "error"}))
     }
   }

--- a/pages/checkIn.tsx
+++ b/pages/checkIn.tsx
@@ -25,8 +25,9 @@ import usersHandler from '@api/users'
 import itemDefinitionsHandler from '@api/itemDefinitions'
 import categoriesHandler from '@api/categories'
 import { useRouter } from 'next/router'
-import { useAppSelector } from 'store'
+import { useAppDispatch, useAppSelector } from 'store'
 import { KioskState } from 'store/types'
+import { showSnackbar } from 'store/snackbar'
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   return {
@@ -52,6 +53,7 @@ export default function CheckInPage({
   const theme = useTheme()
   const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
   const router = useRouter()
+  const dispatch = useAppDispatch()
   const inventoryItem = !!router.query.inventoryItem
     ? JSON.parse(decodeURIComponent(router.query.inventoryItem as string))
     : undefined
@@ -68,7 +70,7 @@ export default function CheckInPage({
       CheckInOutFormDataToInventoryItemRequest(formData)
 
     // TODO better way of coding URLs
-    await fetch(
+    const response = await fetch(
       `http://localhost:3000/api/inventoryItems/checkIn?quantity=${formData.quantityDelta}`,
       {
         method: 'POST',
@@ -78,6 +80,14 @@ export default function CheckInPage({
         body: JSON.stringify(inventoryItem),
       }
     )
+
+    const data = await response.json()
+
+    if (data.success) {
+      dispatch(showSnackbar({message: "Item successfully checked out.", severity: "success"}))
+    } else {
+      dispatch(showSnackbar({message: data.message, severity: "error"}))
+    }
   }
 
   return (

--- a/pages/checkIn.tsx
+++ b/pages/checkIn.tsx
@@ -85,10 +85,8 @@ export default function CheckInPage({
 
     if (data.success) {
       // @ts-ignore
-      // @ts-ignore
       dispatch(showSnackbar({message: "Item successfully checked in.", severity: "success"}))
     } else {
-      // @ts-ignore
       // @ts-ignore
       dispatch(showSnackbar({message: data.message, severity: "error"}))
     }

--- a/pages/checkOut.tsx
+++ b/pages/checkOut.tsx
@@ -25,8 +25,9 @@ import itemDefinitionsHandler from '@api/itemDefinitions'
 import { apiWrapper } from 'utils/apiWrappers'
 import categoriesHandler from '@api/categories'
 import { useRouter } from 'next/router'
-import { useAppSelector } from 'store'
+import { useAppDispatch, useAppSelector } from 'store'
 import { KioskState } from 'store/types'
+import { showSnackbar } from 'store/snackbar'
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   return {
@@ -53,6 +54,7 @@ export default function CheckOutPage({
   const inventoryItem = !!router.query.inventoryItem
     ? JSON.parse(decodeURIComponent(router.query.inventoryItem as string))
     : undefined
+  const dispatch = useAppDispatch()
 
   const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
 
@@ -65,7 +67,7 @@ export default function CheckOutPage({
       CheckInOutFormDataToInventoryItemRequest(formData)
 
     // TODO better way of coding URLs
-    await fetch(
+    const response = await fetch(
       `http://localhost:3000/api/inventoryItems/checkOut?quantity=${formData.quantityDelta}`,
       {
         method: 'POST',
@@ -75,6 +77,13 @@ export default function CheckOutPage({
         body: JSON.stringify(inventoryItem),
       }
     )
+    const data = await response.json()
+
+    if (data.success) {
+      dispatch(showSnackbar({message: "Item successfully checked out.", severity: "success"}))
+    } else {
+      dispatch(showSnackbar({message: data.message, severity: "error"}))
+    }
   }
   const kioskMode = useAppSelector(
     (state: { kiosk: KioskState }) => state.kiosk

--- a/pages/checkOut.tsx
+++ b/pages/checkOut.tsx
@@ -80,8 +80,10 @@ export default function CheckOutPage({
     const data = await response.json()
 
     if (data.success) {
+      // @ts-ignore
       dispatch(showSnackbar({message: "Item successfully checked out.", severity: "success"}))
     } else {
+      // @ts-ignore
       dispatch(showSnackbar({message: data.message, severity: "error"}))
     }
   }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,6 +6,7 @@ import { showSnackbar } from 'store/snackbar';
 export default function DashboardPage() {
   const dispatch = useAppDispatch();
   return (
+    // @ts-ignore
     <Button onClick={() => dispatch(showSnackbar({ message: "hello!", severity: "success"}))}>
       Open snackbar
     </Button>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,10 +1,13 @@
 import { Button } from '@mui/material'
 import DialogLink from 'components/DialogLink'
+import { useAppDispatch } from 'store'
+import { showSnackbar } from 'store/snackbar';
 
 export default function DashboardPage() {
+  const dispatch = useAppDispatch();
   return (
-    <DialogLink href={'/dialog/test'}>
-      <Button>Take me to dialog</Button>
-    </DialogLink>
+    <Button onClick={() => dispatch(showSnackbar({ message: "hello!", severity: "success"}))}>
+      Open snackbar
+    </Button>
   )
 }

--- a/store/index.ts
+++ b/store/index.ts
@@ -1,6 +1,7 @@
 import { configureStore, combineReducers } from '@reduxjs/toolkit'
 import kioskReducer, { kioskSlice } from 'store/kiosk'
-import { KioskState } from 'store/types'
+import snackbarReducer, { snackbarSlice } from 'store/snackbar'
+import { KioskState, SnackbarState } from 'store/types'
 import { useDispatch, useSelector } from 'react-redux'
 import type { TypedUseSelectorHook } from 'react-redux'
 import { createWrapper } from 'next-redux-wrapper'
@@ -18,6 +19,7 @@ import {
 
 export type RootState = {
   kiosk: KioskState
+  snackbar: SnackbarState
 }
 
 function preloadState(): RootState {
@@ -25,17 +27,23 @@ function preloadState(): RootState {
     kiosk: {
       enabled: false,
     },
+    snackbar: {
+      open: false,
+      message: ""
+    }
   }
 }
 
 const rootReducer = combineReducers({
   [kioskSlice.name]: kioskSlice.reducer,
+  [snackbarSlice.name]: snackbarSlice.reducer
 })
 
 const makeConfiguredStore = () =>
   configureStore({
     reducer: {
       kiosk: kioskReducer,
+      snackbar: snackbarReducer,
     },
     preloadedState: preloadState(),
     devTools: process.env.NODE_ENV !== 'production',
@@ -48,7 +56,7 @@ const makeStore = () => {
   } else {
     const persistConfig = {
       key: 'root',
-      whitelist: ['kiosk'],
+      whitelist: ['kiosk', 'snackbar'],
       storage,
     }
 

--- a/store/snackbar.ts
+++ b/store/snackbar.ts
@@ -1,0 +1,26 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { SnackbarState } from './types';
+
+const initialState: SnackbarState = {
+  open: false,
+  message: ''
+};
+
+export const snackbarSlice = createSlice({
+  name: 'snackbar',
+  initialState,
+  reducers: {
+    showSnackbar: (state, action: PayloadAction<Omit<SnackbarState, "open">>) => {
+      state.open = true;
+      state.message = action.payload.message;
+      state.severity = action.payload.severity;
+    },
+    clearSnackbar: (state) => {
+      state.open = false;
+    }
+  }
+});
+
+export const { showSnackbar, clearSnackbar } = snackbarSlice.actions;
+
+export default snackbarSlice.reducer;

--- a/store/types.ts
+++ b/store/types.ts
@@ -1,3 +1,9 @@
 export interface KioskState {
   enabled: boolean
 }
+
+export interface SnackbarState {
+  open: boolean
+  message: string
+  severity?: 'success' | 'info' | 'warning' | 'error';
+}


### PR DESCRIPTION
Added in a snackbar service using Redux to make it easy to display a snackbar. Check out examples in `pages/checkIn.tsx` `pages/checkOut.tsx` and `components/InventoryItemListKebab/index.tsx`

When this gets merged, remind me to update documentation for using this service.