### PR TITLE
CCAHT-127-Put-ItemDefinitionList-component-onto-Items-Settings-page-and-hook-up-to-backend

### DIFF
--- a/pages/settings/items.tsx
+++ b/pages/settings/items.tsx
@@ -1,8 +1,28 @@
 import { Button, Typography, Unstable_Grid2 as Grid2 } from '@mui/material'
 import SearchField from 'components/SearchField'
 import AddIcon from '@mui/icons-material/Add'
+import ItemDefinitionList from 'components/ItemDefinitionList'
+import { ItemDefinitionResponse } from 'utils/types'
+import { GetServerSidePropsContext } from 'next'
+import { apiWrapper } from 'utils/apiWrappers'
+import itemDefinitionsHandler from '@api/itemDefinitions'
+import { useRouter } from 'next/router'
 
-export default function ItemsPage() {
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  return {
+    props: {
+      itemDefinitions: await apiWrapper(itemDefinitionsHandler, context)
+    }
+  }
+}
+
+interface Props {
+  itemDefinitions: ItemDefinitionResponse[]
+}
+
+export default function ItemsPage({ itemDefinitions }: Props) {
+  const router = useRouter()
+
   return (
     <Grid2 container my={2} sx={{ flexGrow: 1, px: 2 }} gap={2}>
       <Grid2 xs={12} container direction={'row'}>
@@ -22,6 +42,10 @@ export default function ItemsPage() {
       <Grid2 xs={12} md={5} lg={4} sx={{ px: 2 }}>
         <SearchField />
       </Grid2>
+      <ItemDefinitionList
+        itemDefinitions={itemDefinitions}
+        search={router.query.search as string}
+      />
     </Grid2>
   )
 }


### PR DESCRIPTION
Hooked up Items Settings page with database to populate the table.
Hooked up search query to table, now supports searching by name, category, attribute, and consumer.

Note: The create new item button functionality will be dealt with in another PR.

To test, just go to `settings/items` page.

**DO NOT** merge until [CCAHT-125](https://team-16679321250140.atlassian.net/browse/CCAHT-125) / #81  and [CCAHT-126](https://team-16679321250140.atlassian.net/browse/CCAHT-126) / #83  are merged in!

As with [CCAHT-126](https://team-16679321250140.atlassian.net/browse/CCAHT-126) / #83: There is no deliberate mobile support since the table only works well on desktop, however, the setup is somewhat responsive. If we add a mobile version of the table later, this might need to be changed.

[CCAHT-125]: https://team-16679321250140.atlassian.net/browse/CCAHT-125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CCAHT-126]: https://team-16679321250140.atlassian.net/browse/CCAHT-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CCAHT-126]: https://team-16679321250140.atlassian.net/browse/CCAHT-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ