### PR TITLE
Ccaht 128 hook up create new item button to create new item form dialog

### DIFF
--- a/pages/settings/items.tsx
+++ b/pages/settings/items.tsx
@@ -31,7 +31,7 @@ export default function ItemsPage({ itemDefinitions }: Props) {
           Items
         </Typography>
         <Grid2 ml="auto" mr={6}>
-          <DialogLink href='items/new'>
+          <DialogLink href='/items/new' backHref='/settings/items'>
             <Button
               variant="outlined"
               startIcon={<AddIcon />}

--- a/pages/settings/items.tsx
+++ b/pages/settings/items.tsx
@@ -7,6 +7,7 @@ import { GetServerSidePropsContext } from 'next'
 import { apiWrapper } from 'utils/apiWrappers'
 import itemDefinitionsHandler from '@api/itemDefinitions'
 import { useRouter } from 'next/router'
+import DialogLink from 'components/DialogLink'
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   return {
@@ -30,13 +31,15 @@ export default function ItemsPage({ itemDefinitions }: Props) {
           Items
         </Typography>
         <Grid2 ml="auto" mr={6}>
-          <Button
-            variant="outlined"
-            startIcon={<AddIcon />}
-            sx={{ width: '100%' }}
-          >
-            Create New Item
-          </Button>
+          <DialogLink href='items/new'>
+            <Button
+              variant="outlined"
+              startIcon={<AddIcon />}
+              sx={{ width: '100%' }}
+            >
+              Create New Item
+            </Button>
+          </DialogLink>
         </Grid2>
       </Grid2>
       <Grid2 xs={12} md={5} lg={4} sx={{ px: 2 }}>

--- a/utils/transformations.ts
+++ b/utils/transformations.ts
@@ -1,6 +1,5 @@
 import { ItemDefinitionFormData } from 'components/UpsertItemForm'
 import { AttributeFormData } from 'components/UpsertAttributeForm'
-import { ItemDefinitionFormData } from 'components/UpsertItemForm'
 import {
   AttributeRequest,
   CheckInOutFormData,
@@ -94,14 +93,4 @@ export function DateToReadableDateString(date: Date) {
   }
 
   return new Date(date).toLocaleString('en-US', dateOptions).replace(' at', '')
-}
-
-export function itemDefinitionFormDataToItemDefinitionRequest(
-  formData: ItemDefinitionFormData
-): ItemDefinitionRequest {
-  return {
-    ...formData,
-    category: formData.category._id,
-    attributes: formData.attributes.map((attr) => attr._id),
-  }
 }


### PR DESCRIPTION
Hooks up `Create New Item` button to the new item dialog in `items/new` using the `DialogLink` component.
A extra item query param appears after an item is created, this is for the check in page and is not used here.

To test, go to `settings/items` page.

**DO NOT** merge until [CCAHT-127](https://team-16679321250140.atlassian.net/browse/CCAHT-127) / #84 and [CCAHT-62](https://team-16679321250140.atlassian.net/browse/CCAHT-62) / #76 are merged in!

This branch only changes `settings/items.tsx` the other changes are apart of CCAHT-62.

[CCAHT-127]: https://team-16679321250140.atlassian.net/browse/CCAHT-127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CCAHT-62]: https://team-16679321250140.atlassian.net/browse/CCAHT-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ