### PR TITLE
Ccaht 161 add functionality to export to excel button

### DIFF
--- a/components/HistoryList/DesktopHistoryList/index.tsx
+++ b/components/HistoryList/DesktopHistoryList/index.tsx
@@ -112,7 +112,7 @@ const headCells: readonly HeadCell[] = [
     label: 'Date',
     sortable: true,
     sortFn: (log1: LogResponse, log2: LogResponse) => {
-      return comparator(log2.date, log1.date)
+      return comparator(log1.date, log2.date)
     },
   },
   {
@@ -184,7 +184,7 @@ interface Props {
 
 const DEFAULT_ROWS_PER_PAGE = 5
 const DEFAULT_ORDER_BY = 'date'
-const DEFAULT_ORDER = 'asc'
+const DEFAULT_ORDER = 'desc'
 
 export default function DesktopHistoryList(props: Props) {
   const [order, setOrder] = React.useState<Order>(DEFAULT_ORDER)

--- a/components/HistoryList/DesktopHistoryList/index.tsx
+++ b/components/HistoryList/DesktopHistoryList/index.tsx
@@ -197,6 +197,7 @@ export default function DesktopHistoryList(props: Props) {
   )
 
   React.useEffect(() => {
+    // does pagination
     var rowsOnMount = sortTable(props.logs, orderBy, order)
     rowsOnMount = rowsOnMount.slice(0, rowsPerPage)
 
@@ -204,6 +205,7 @@ export default function DesktopHistoryList(props: Props) {
     setPage(0)
   }, [props.logs])
 
+  // when a header is clicked
   const handleRequestSort = React.useCallback(
     (_e: React.MouseEvent<unknown>, newOrderBy: keyof HistoryTableData) => {
       const isAsc = orderBy === newOrderBy && order === 'asc'
@@ -218,6 +220,7 @@ export default function DesktopHistoryList(props: Props) {
     [order, orderBy, page, rowsPerPage, props.logs]
   )
 
+  // when the change page buttons are clicked
   const handleChangePage = (_e: unknown, newPage: number) => {
     setPage(newPage)
     const sortedRows = sortTable(props.logs, orderBy, order)

--- a/components/HistoryList/DesktopHistoryList/index.tsx
+++ b/components/HistoryList/DesktopHistoryList/index.tsx
@@ -179,6 +179,7 @@ interface Props {
   endDate: string
   startDate: string
   internal: boolean
+  setTableData: React.Dispatch<React.SetStateAction<LogResponse[]>>
 }
 
 const DEFAULT_ROWS_PER_PAGE = 5
@@ -194,7 +195,6 @@ export default function DesktopHistoryList(props: Props) {
   const [visibleRows, setVisibleRows] = React.useState<LogResponse[]>(
     [] as LogResponse[]
   )
-  const [tableData, setTableData] = React.useState<LogResponse[]>([])
 
   React.useEffect(() => {
     let newTableData: LogResponse[] = deepCopy(props.logs)
@@ -245,7 +245,7 @@ export default function DesktopHistoryList(props: Props) {
         return log.item.itemDefinition.category?.name === props.category
       })
     }
-    setTableData(newTableData)
+    props.setTableData(newTableData)
     var rowsOnMount = sortTable(newTableData, orderBy, order)
     rowsOnMount = rowsOnMount.slice(0, rowsPerPage)
 
@@ -265,19 +265,19 @@ export default function DesktopHistoryList(props: Props) {
       setOrder(toggledOrder)
       setOrderBy(newOrderBy)
 
-      const sortedRows = sortTable(tableData, newOrderBy, toggledOrder)
+      const sortedRows = sortTable(props.logs, newOrderBy, toggledOrder)
       const updatedRows = sortedRows.slice(
         page * rowsPerPage,
         page * rowsPerPage + rowsPerPage
       )
       setVisibleRows(updatedRows)
     },
-    [order, orderBy, page, rowsPerPage, tableData]
+    [order, orderBy, page, rowsPerPage, props.logs]
   )
 
   const handleChangePage = (_e: unknown, newPage: number) => {
     setPage(newPage)
-    const sortedRows = sortTable(tableData, orderBy, order)
+    const sortedRows = sortTable(props.logs, orderBy, order)
 
     const updatedRows = sortedRows.slice(
       newPage * rowsPerPage,
@@ -292,7 +292,7 @@ export default function DesktopHistoryList(props: Props) {
     const updatedRowsPerPage = parseInt(event.target.value, 10)
     setRowsPerPage(updatedRowsPerPage)
     setPage(0)
-    const sortedRows = sortTable(tableData, orderBy, order)
+    const sortedRows = sortTable(props.logs, orderBy, order)
 
     const updatedRows = sortedRows.slice(
       page * updatedRowsPerPage,
@@ -321,7 +321,7 @@ export default function DesktopHistoryList(props: Props) {
       <TablePagination
         rowsPerPageOptions={[5, 10, 25]}
         component="div"
-        count={tableData.length}
+        count={props.logs.length}
         rowsPerPage={rowsPerPage}
         page={page}
         onPageChange={handleChangePage}

--- a/components/HistoryList/MobileHistoryList/index.tsx
+++ b/components/HistoryList/MobileHistoryList/index.tsx
@@ -1,9 +1,7 @@
 import { List } from '@mui/material'
 import React from 'react'
-import deepCopy from 'utils/deepCopy'
 import { LogResponse } from 'utils/types'
 import MobileHistoryListItem from 'components/HistoryList/MobileHistoryList/MobileHistoryListItem'
-import { dateToReadableDateString } from 'utils/transformations'
 
 interface Props {
   logs: LogResponse[]
@@ -28,72 +26,23 @@ function dateComparator(v1: Date, v2: Date) {
 }
 
 export default function MobileHistoryList(props: Props) {
+  const [visibleRows, setVisibleRows] = React.useState<LogResponse[]>(
+    props.logs
+  )
+
   React.useEffect(() => {
-    let newTableData: LogResponse[] = deepCopy(props.logs)
-
-    if (props.internal) {
-      newTableData = newTableData.filter(
-        (log) => log.item.itemDefinition.internal
-      )
-    }
-
-    if (props.search) {
-      const search = props.search.toLowerCase()
-      newTableData = newTableData.filter((log) => {
-        return (
-          log.staff.name.toLowerCase().includes(search) ||
-          log.item.itemDefinition.name.toLowerCase().includes(search) ||
-          (log.item.attributes &&
-            log.item.attributes
-              .map((attr) =>
-                `${attr.attribute.name}: ${attr.value}`.toLowerCase()
-              )
-              .join(' ')
-              .includes(search)) ||
-          (log.item.itemDefinition.category &&
-            log.item.itemDefinition.category.name
-              .toLowerCase()
-              .includes(search)) ||
-          log.quantityDelta.toString().toLowerCase().includes(search) ||
-          dateToReadableDateString(log.date).toLowerCase().includes(search)
-        )
-      })
-    }
-
-    if (props.startDate || props.endDate) {
-      // if props.startDate or props.endDate are not present, use an arbitrarily far-away date
-      const startDate = new Date(props.startDate ?? '1000-01-01').getTime()
-      const endDate = new Date(props.endDate ?? '9999-01-01').getTime()
-      newTableData = newTableData.filter((log) => {
-        return (
-          new Date(log.date).getTime() >= startDate &&
-          new Date(log.date).getTime() <= endDate
-        )
-      })
-    }
-
-    if (props.category) {
-      newTableData = newTableData.filter((log) => {
-        return log.item.itemDefinition.category?.name === props.category
-      })
-    }
-
     // sort table by date
-    newTableData.sort((log1: LogResponse, log2: LogResponse) =>
-      dateComparator(log2.date, log1.date)
+    const newVisibleRows = props.logs.sort(
+      (log1: LogResponse, log2: LogResponse) =>
+        dateComparator(log2.date, log1.date)
     )
 
-    props.setTableData(newTableData)
-  }, [
-    props.search,
-    props.category,
-    props.startDate,
-    props.endDate,
-    props.internal,
-  ])
+    setVisibleRows(newVisibleRows)
+  }, [props.logs])
+
   return (
     <List sx={{ width: '100%', bgcolor: 'background.paper' }}>
-      {props.logs.map((log) => (
+      {visibleRows.map((log) => (
         <MobileHistoryListItem log={log} key={log._id} />
       ))}
     </List>

--- a/components/HistoryList/MobileHistoryList/index.tsx
+++ b/components/HistoryList/MobileHistoryList/index.tsx
@@ -12,6 +12,7 @@ interface Props {
   endDate: string
   startDate: string
   internal: boolean
+  setTableData: React.Dispatch<React.SetStateAction<LogResponse[]>>
 }
 
 function dateComparator(v1: Date, v2: Date) {
@@ -27,9 +28,6 @@ function dateComparator(v1: Date, v2: Date) {
 }
 
 export default function MobileHistoryList(props: Props) {
-  const [filteredData, setFilteredData] = React.useState<LogResponse[]>(
-    [] as LogResponse[]
-  )
   React.useEffect(() => {
     let newTableData: LogResponse[] = deepCopy(props.logs)
 
@@ -85,7 +83,7 @@ export default function MobileHistoryList(props: Props) {
       dateComparator(log2.date, log1.date)
     )
 
-    setFilteredData(newTableData)
+    props.setTableData(newTableData)
   }, [
     props.search,
     props.category,
@@ -95,7 +93,7 @@ export default function MobileHistoryList(props: Props) {
   ])
   return (
     <List sx={{ width: '100%', bgcolor: 'background.paper' }}>
-      {filteredData.map((log) => (
+      {props.logs.map((log) => (
         <MobileHistoryListItem log={log} key={log._id} />
       ))}
     </List>

--- a/components/HistoryList/MobileHistoryList/index.tsx
+++ b/components/HistoryList/MobileHistoryList/index.tsx
@@ -34,7 +34,7 @@ export default function MobileHistoryList(props: Props) {
     // sort table by date
     const newVisibleRows = props.logs.sort(
       (log1: LogResponse, log2: LogResponse) =>
-        dateComparator(log2.date, log1.date)
+        dateComparator(log1.date, log2.date)
     )
 
     setVisibleRows(newVisibleRows)

--- a/pages/history.tsx
+++ b/pages/history.tsx
@@ -347,7 +347,7 @@ export default function HistoryPage({ logs, categories }: HistoryPageProps) {
       </Grid2>
       {isMobileView ? (
         <MobileHistoryList
-          logs={logs}
+          logs={tableData}
           search={router.query.search as string}
           category={router.query.category as string}
           endDate={router.query.endDate as string}

--- a/pages/history.tsx
+++ b/pages/history.tsx
@@ -57,7 +57,9 @@ function handleExport(logs: LogResponse[]) {
   // to download the file, create an <a> tag, associate the file with it, and click it
   const a = document.createElement('a')
   a.href = URL.createObjectURL(file)
-  a.download = 'fileName'
+
+  // set file name. .slice() to put date in in yyyy-mm-dd format
+  a.download = `Warehouse History ${new Date().toISOString().slice(0, 10)}`
   a.style.display = 'none'
   document.body.appendChild(a)
   a.click()

--- a/pages/history.tsx
+++ b/pages/history.tsx
@@ -61,18 +61,18 @@ function createLogsCsvAsString(logs: LogResponse[]) {
         Item: log.item.itemDefinition.name,
         Attributes:
           log.item.attributes
-            ?.map((attr) =>
-              `${attr.attribute.name}: ${attr.value}`.toLowerCase()
-            )
+            ?.map((attr) => `${attr.attribute.name}: ${attr.value}`)
             .join('; ') ?? '',
         Category: log.item.itemDefinition.category?.name ?? '',
         Quantity: log.quantityDelta,
         Staff: log.staff.name,
-        Date: log.date.toISOString(),
+        Date: new Date(log.date).toISOString(),
       }
       return Object.values(csvRow).join(',')
     })
     .join('\n')
+
+  console.log(csvData)
 }
 
 const updateQuery = (router: NextRouter, key: string, val?: string) => {
@@ -117,7 +117,11 @@ export default function HistoryPage({ logs, categories }: HistoryPageProps) {
         </Typography>
         {!isMobileView && (
           <Grid2 ml="auto" mr={6}>
-            <Button variant="outlined" sx={{ width: '100%' }}>
+            <Button
+              variant="outlined"
+              sx={{ width: '100%' }}
+              onClick={() => createLogsCsvAsString(tableData)}
+            >
               Export To Excel
             </Button>
           </Grid2>

--- a/pages/history.tsx
+++ b/pages/history.tsx
@@ -190,6 +190,29 @@ export default function HistoryPage({ logs, categories }: HistoryPageProps) {
       })
     }
 
+    const startDate = router.query.startDate
+      ? new Date(router.query.startDate as string).getTime()
+      : undefined
+    const endDate = router.query.endDate
+      ? new Date(router.query.endDate as string).getTime()
+      : undefined
+
+    if (router.query.startDate && router.query.endDate) {
+      newTableData = newTableData.filter(
+        (log) =>
+          new Date(log.date).getTime() >= startDate! &&
+          new Date(log.date).getTime() <= endDate!
+      )
+    } else if (router.query.startDate) {
+      newTableData = newTableData.filter(
+        (log) => new Date(log.date).getTime() >= startDate!
+      )
+    } else if (router.query.endDate) {
+      newTableData = newTableData.filter(
+        (log) => new Date(log.date).getTime() <= endDate!
+      )
+    }
+
     if (router.query.startDate || router.query.endDate) {
       // if props.startDate or props.endDate are not present, use an arbitrarily far-away date
       const startDate = new Date(

--- a/pages/history.tsx
+++ b/pages/history.tsx
@@ -85,24 +85,43 @@ function createLogsCsvAsString(logs: LogResponse[]) {
 
   const csvKeysString: string = csvKeys.join(',')
 
-  const csvData: string = logs
-    .map((log) => {
-      const csvRow: CsvRow = {
-        Item: log.item.itemDefinition.name,
-        Attributes:
-          log.item.attributes
-            ?.map((attr) => `${attr.attribute.name}: ${attr.value}`)
-            .join('; ') ?? '',
-        Category: log.item.itemDefinition.category?.name ?? '',
-        Quantity: log.quantityDelta,
-        Staff: log.staff.name,
-        Date: new Date(log.date).toISOString(),
-      }
-      return Object.values(csvRow).join(',')
-    })
+  const csvData: CsvRow[] = logs.map((log) => {
+    const csvRow: CsvRow = {
+      Item: log.item.itemDefinition.name,
+      Attributes:
+        log.item.attributes
+          ?.map((attr) => `${attr.attribute.name}: ${attr.value}`)
+          .join('; ') ?? '',
+      Category: log.item.itemDefinition.category?.name ?? '',
+      Quantity: log.quantityDelta,
+      Staff: log.staff.name,
+      Date: new Date(log.date).toISOString(),
+    }
+    return csvRow
+  })
+
+  // sort rows by date
+  const compareFn = (d1: Date, d2: Date) => {
+    if (d1 < d2) {
+      return -1
+    }
+
+    if (d1 > d2) {
+      return 1
+    }
+
+    return 0
+  }
+
+  csvData.sort((row1: CsvRow, row2: CsvRow) =>
+    compareFn(new Date(row2.Date), new Date(row1.Date))
+  )
+
+  const csvDataString: string = csvData
+    .map((data) => Object.values(data).join(','))
     .join('\n')
 
-  return `${csvKeysString}\n${csvData}`
+  return `${csvKeysString}\n${csvDataString}`
 }
 
 const updateQuery = (router: NextRouter, key: string, val?: string) => {

--- a/pages/history.tsx
+++ b/pages/history.tsx
@@ -38,6 +38,15 @@ interface HistoryPageProps {
   categories: CategoryResponse[]
 }
 
+interface CsvRow {
+  Item: string
+  Attributes: string
+  Category: string
+  Quantity: number
+  Staff: string
+  Date: string
+}
+
 const updateQuery = (router: NextRouter, key: string, val?: string) => {
   if (!val) removeURLQueryParam(router, key)
   else addURLQueryParam(router, key, val)

--- a/pages/history.tsx
+++ b/pages/history.tsx
@@ -48,6 +48,33 @@ interface CsvRow {
   Date: string
 }
 
+function createLogsCsvAsString(logs: LogResponse[]) {
+  /* Creates CSV-formatted string by:
+   * 1. creating a CsvRow obj
+   * 2. converted obj to string by separating the object values by with a comma
+   * 3. creating an array of CsvRow obj converted strings
+   * 4. joining each array element with a newline
+   */
+  const csvData: string = logs
+    .map((log) => {
+      const csvRow: CsvRow = {
+        Item: log.item.itemDefinition.name,
+        Attributes:
+          log.item.attributes
+            ?.map((attr) =>
+              `${attr.attribute.name}: ${attr.value}`.toLowerCase()
+            )
+            .join('; ') ?? '',
+        Category: log.item.itemDefinition.category?.name ?? '',
+        Quantity: log.quantityDelta,
+        Staff: log.staff.name,
+        Date: log.date.toISOString(),
+      }
+      return Object.values(csvRow).join(',')
+    })
+    .join('\n')
+}
+
 const updateQuery = (router: NextRouter, key: string, val?: string) => {
   if (!val) removeURLQueryParam(router, key)
   else addURLQueryParam(router, key, val)

--- a/pages/history.tsx
+++ b/pages/history.tsx
@@ -48,13 +48,39 @@ interface CsvRow {
   Date: string
 }
 
+function handleExport(logs: LogResponse[]) {
+  const csvString = createLogsCsvAsString(logs)
+  const file: Blob = new Blob([csvString], { type: 'text/csv' })
+
+  // to download the file, create an <a> tag, associate the file with it, and click it
+  const a = document.createElement('a')
+  a.href = URL.createObjectURL(file)
+  a.download = 'fileName'
+  a.style.display = 'none'
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+}
+
 function createLogsCsvAsString(logs: LogResponse[]) {
   /* Creates CSV-formatted string by:
-   * 1. creating a CsvRow obj
-   * 2. converted obj to string by separating the object values by with a comma
-   * 3. creating an array of CsvRow obj converted strings
-   * 4. joining each array element with a newline
+   * 1. Create the header row
+   * 2. creating a CsvRow obj
+   * 3. converted obj to string by separating the object values by with a comma
+   * 4. creating an array of CsvRow obj converted strings
+   * 5. joining each array element with a newline
    */
+  const csvKeys: (keyof CsvRow)[] = [
+    'Item',
+    'Attributes',
+    'Category',
+    'Quantity',
+    'Staff',
+    'Date',
+  ]
+
+  const csvKeysString: string = csvKeys.join(',')
+
   const csvData: string = logs
     .map((log) => {
       const csvRow: CsvRow = {
@@ -72,7 +98,7 @@ function createLogsCsvAsString(logs: LogResponse[]) {
     })
     .join('\n')
 
-  console.log(csvData)
+  return `${csvKeysString}\n${csvData}`
 }
 
 const updateQuery = (router: NextRouter, key: string, val?: string) => {
@@ -120,7 +146,7 @@ export default function HistoryPage({ logs, categories }: HistoryPageProps) {
             <Button
               variant="outlined"
               sx={{ width: '100%' }}
-              onClick={() => createLogsCsvAsString(tableData)}
+              onClick={() => handleExport(tableData)}
             >
               Export To Excel
             </Button>

--- a/pages/history.tsx
+++ b/pages/history.tsx
@@ -23,6 +23,7 @@ import DesktopHistoryList from 'components/HistoryList/DesktopHistoryList'
 import MobileHistoryList from 'components/HistoryList/MobileHistoryList'
 import { Clear } from '@mui/icons-material'
 import LogsHandler from '@api/logs'
+import React from 'react'
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   return {
@@ -76,6 +77,7 @@ const renderInternalCheckbox = (router: NextRouter, isMobileView: boolean) => {
 }
 
 export default function HistoryPage({ logs, categories }: HistoryPageProps) {
+  const [tableData, setTableData] = React.useState<LogResponse[]>(logs)
   const router = useRouter()
   const theme = useTheme()
   const isMobileView = useMediaQuery(theme.breakpoints.down('md'))
@@ -229,6 +231,7 @@ export default function HistoryPage({ logs, categories }: HistoryPageProps) {
           endDate={router.query.endDate as string}
           startDate={router.query.startDate as string}
           internal={!!router.query.internal}
+          setTableData={setTableData}
         />
       ) : (
         <DesktopHistoryList
@@ -238,6 +241,7 @@ export default function HistoryPage({ logs, categories }: HistoryPageProps) {
           endDate={router.query.endDate as string}
           startDate={router.query.startDate as string}
           internal={!!router.query.internal}
+          setTableData={setTableData}
         />
       )}
     </Grid2>


### PR DESCRIPTION
Now, when clicking the "Export to Excel" button on the history page, it downloads a csv with the currently visible logs, taking into account any filters, and always sorting by date.

To do this I had to pull the state of each list out into the page, which is a cleaner pattern anyways.
Give it a try on your machine and make sure you can easily open up the downloaded file in a spreadsheet, and also review the format of the spreadsheet.