### PR TITLE
CCAHT-169 removed document versioning from schemas

### DIFF
--- a/server/models/Attribute.ts
+++ b/server/models/Attribute.ts
@@ -1,21 +1,26 @@
 import { model, Schema, Document, models, Model } from 'mongoose'
 import { Attribute } from 'utils/types'
 
-const AttributeSchema = new Schema({
-  name: {
-    type: String,
-    required: true,
+const AttributeSchema = new Schema(
+  {
+    name: {
+      type: String,
+      required: true,
+    },
+    // TODO: change from mixed to one of "text", "number" or string[]
+    possibleValues: {
+      type: Schema.Types.Mixed,
+      required: true,
+    },
+    color: {
+      type: String,
+      required: true,
+    },
   },
-  // TODO: change from mixed to one of "text", "number" or string[]
-  possibleValues: {
-    type: Schema.Types.Mixed,
-    required: true,
-  },
-  color: {
-    type: String,
-    required: true,
-  },
-})
+  {
+    versionKey: false,
+  }
+)
 
 export interface AttributeDocument extends Omit<Attribute, '_id'>, Document {}
 

--- a/server/models/Category.ts
+++ b/server/models/Category.ts
@@ -1,12 +1,17 @@
 import { model, Schema, Document, models, Model } from 'mongoose'
 import { Category } from 'utils/types'
 
-const CategorySchema = new Schema({
-  name: {
-    type: String,
-    required: true,
+const CategorySchema = new Schema(
+  {
+    name: {
+      type: String,
+      required: true,
+    },
   },
-})
+  {
+    versionKey: false,
+  }
+)
 
 export interface CategoryDocument extends Omit<Category, '_id'>, Document {}
 

--- a/server/models/InventoryItem.ts
+++ b/server/models/InventoryItem.ts
@@ -1,35 +1,40 @@
 import { model, Schema, Document, models, Model } from 'mongoose'
 import { InventoryItem } from 'utils/types'
 
-const InventoryItemSchema = new Schema({
-  itemDefinition: {
-    type: Schema.Types.ObjectId,
-    ref: 'ItemDefinition',
-    required: true,
-  },
-  attributes: [
-    {
-      attribute: {
-        _id: false,
-        type: Schema.Types.ObjectId,
-        required: true,
-        ref: 'Attribute',
-      },
-      // value is either string or number
-      value: { type: Schema.Types.Mixed, required: true },
-      _id: false,
+const InventoryItemSchema = new Schema(
+  {
+    itemDefinition: {
+      type: Schema.Types.ObjectId,
+      ref: 'ItemDefinition',
+      required: true,
     },
-  ],
-  quantity: {
-    type: Number,
-    required: true,
+    attributes: [
+      {
+        attribute: {
+          _id: false,
+          type: Schema.Types.ObjectId,
+          required: true,
+          ref: 'Attribute',
+        },
+        // value is either string or number
+        value: { type: Schema.Types.Mixed, required: true },
+        _id: false,
+      },
+    ],
+    quantity: {
+      type: Number,
+      required: true,
+    },
+    assignee: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: false,
+    },
   },
-  assignee: {
-    type: Schema.Types.ObjectId,
-    ref: 'User',
-    required: false,
-  },
-})
+  {
+    versionKey: false,
+  }
+)
 
 export interface InventoryItemDocument
   extends Omit<InventoryItem, '_id'>,

--- a/server/models/ItemDefinition.ts
+++ b/server/models/ItemDefinition.ts
@@ -1,37 +1,42 @@
 import { model, Schema, Document, models, Model } from 'mongoose'
 import { ItemDefinition } from 'utils/types'
 
-const ItemDefinitionSchema = new Schema({
-  name: {
-    type: String,
-    required: true,
+const ItemDefinitionSchema = new Schema(
+  {
+    name: {
+      type: String,
+      required: true,
+    },
+    category: {
+      type: Schema.Types.ObjectId,
+      ref: 'Category',
+      required: false,
+    },
+    attributes: {
+      type: [{ type: Schema.Types.ObjectId, ref: 'Attribute' }],
+      required: false,
+      default: [],
+    },
+    internal: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    lowStockThreshold: {
+      type: Number,
+      required: false,
+      default: -1,
+    },
+    criticalStockThreshold: {
+      type: Number,
+      required: false,
+      default: -1,
+    },
   },
-  category: {
-    type: Schema.Types.ObjectId,
-    ref: 'Category',
-    required: false,
-  },
-  attributes: {
-    type: [{ type: Schema.Types.ObjectId, ref: 'Attribute' }],
-    required: false,
-    default: [],
-  },
-  internal: {
-    type: Boolean,
-    required: false,
-    default: false,
-  },
-  lowStockThreshold: {
-    type: Number,
-    required: false,
-    default: -1,
-  },
-  criticalStockThreshold: {
-    type: Number,
-    required: false,
-    default: -1,
-  },
-})
+  {
+    versionKey: false,
+  }
+)
 
 export interface ItemDefinitionDocument
   extends Omit<ItemDefinition, '_id'>,

--- a/server/models/Log.ts
+++ b/server/models/Log.ts
@@ -1,26 +1,31 @@
 import { model, Schema, Document, models, Model } from 'mongoose'
 import { Log } from 'utils/types'
 
-const LogSchema = new Schema({
-  staff: {
-    type: Schema.Types.ObjectId,
-    ref: 'User',
-    required: true,
+const LogSchema = new Schema(
+  {
+    staff: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+    },
+    item: {
+      type: Schema.Types.ObjectId,
+      ref: 'InventoryItem',
+      required: true,
+    },
+    quantityDelta: {
+      type: Number,
+      required: true,
+    },
+    date: {
+      type: Date,
+      required: true,
+    },
   },
-  item: {
-    type: Schema.Types.ObjectId,
-    ref: 'InventoryItem',
-    required: true,
-  },
-  quantityDelta: {
-    type: Number,
-    required: true,
-  },
-  date: {
-    type: Date,
-    required: true,
-  },
-})
+  {
+    versionKey: false,
+  }
+)
 
 export interface LogDocument extends Omit<Log, '_id'>, Document {}
 

--- a/server/models/NotificationEmail.ts
+++ b/server/models/NotificationEmail.ts
@@ -1,13 +1,24 @@
 import { model, Schema, Document, models, Model } from 'mongoose'
 import { NotificationEmail } from 'utils/types'
 
-const NotificationEmailSchema = new Schema ({
+const NotificationEmailSchema = new Schema(
+  {
     emails: {
-        type: [String],
-        required: true,
-    }
-})
+      type: [String],
+      required: true,
+    },
+  },
+  {
+    versionKey: false,
+  }
+)
 
-export interface NotificationEmailDocument extends Omit<NotificationEmail, '_id'>, Document {}
+export interface NotificationEmailDocument
+  extends Omit<NotificationEmail, '_id'>,
+    Document {}
 export default (models.NotificationEmail as Model<NotificationEmailDocument>) ||
-  model<NotificationEmailDocument>('NotificationEmail', NotificationEmailSchema, 'notificationEmails')
+  model<NotificationEmailDocument>(
+    'NotificationEmail',
+    NotificationEmailSchema,
+    'notificationEmails'
+  )

--- a/server/models/User.ts
+++ b/server/models/User.ts
@@ -1,20 +1,25 @@
 import { model, Schema, Document, models, Model } from 'mongoose'
 import { User } from 'utils/types'
 
-const UserSchema = new Schema({
-  name: {
-    type: String,
-    required: true,
+const UserSchema = new Schema(
+  {
+    name: {
+      type: String,
+      required: true,
+    },
+    email: {
+      type: String,
+      required: true,
+    },
+    image: {
+      type: String,
+      required: true,
+    },
   },
-  email: {
-    type: String,
-    required: true,
-  },
-  image: {
-    type: String,
-    required: true,
-  },
-})
+  {
+    versionKey: false,
+  }
+)
 
 export interface UserDocument extends Omit<User, '_id'>, Document {}
 


### PR DESCRIPTION
Here's the explanation. Fix was to disable document versioning.

![image](https://user-images.githubusercontent.com/71574118/235996765-217e8b8e-c218-40d3-9064-254bf032b673.png)

Prettier made it look like a lot more changes than it actually is. The only change is adding this to all schema definitions

```
{
    versionKey: false,
}
```