### PR TITLE
Ccaht 136 hook up upsert attribute form to create new attribute button

### DIFF
--- a/pages/api/attributes/[attributeId].ts
+++ b/pages/api/attributes/[attributeId].ts
@@ -45,7 +45,7 @@ export default async function attributeHandler(
         )
 
         return res.status(200).json({
-          succcess: true,
+          success: true,
           payload: {},
         })
       }

--- a/pages/settings/attributes/[attributeId]/edit.tsx
+++ b/pages/settings/attributes/[attributeId]/edit.tsx
@@ -1,3 +1,4 @@
+import { LoadingButton } from '@mui/lab'
 import {
   Button,
   DialogActions,
@@ -19,6 +20,7 @@ export default function AttributeEditForm() {
   const [attributeFormData, setAttributeFormData] = useState<AttributeFormData>(
     {} as AttributeFormData
   )
+  const [loading, setLoading] = useState(false)
   const router = useRouter()
   const { id } = router.query
   useEffect(() => {
@@ -45,8 +47,8 @@ export default function AttributeEditForm() {
             : attributeFormData.valueType,
       }),
     })
+
     await router.push('/settings/attributes')
-    // router.reload()
   }
 
   const handleClose = () => {
@@ -68,9 +70,16 @@ export default function AttributeEditForm() {
         <Button onClick={handleClose} color="inherit">
           Cancel
         </Button>
-        <Button onClick={() => handleSubmit(attributeFormData)} color="primary">
+        <LoadingButton
+          loading={loading}
+          onClick={async () => {
+            setLoading(true)
+            await handleSubmit(attributeFormData)
+            setLoading(false)
+          }}
+        >
           Submit
-        </Button>
+        </LoadingButton>
       </DialogActions>
     </>
   )

--- a/pages/settings/attributes/[attributeId]/edit.tsx
+++ b/pages/settings/attributes/[attributeId]/edit.tsx
@@ -50,7 +50,7 @@ export default function AttributeEditForm() {
       )
       return
     }
-    
+
     // update attribute
     const response = await fetch(`/api/attributes/${id}`, {
       method: 'PUT',
@@ -65,6 +65,9 @@ export default function AttributeEditForm() {
             : attributeFormData.valueType,
       }),
     })
+
+    // close dialog
+    await router.push('/settings/attributes')
 
     // handle snackbar logic
     const data = await response.json()
@@ -83,9 +86,6 @@ export default function AttributeEditForm() {
         })
       )
     }
-
-    // close dialog
-    await router.push('/settings/attributes')
   }
 
   const handleClose = () => {

--- a/pages/settings/attributes/create.tsx
+++ b/pages/settings/attributes/create.tsx
@@ -23,6 +23,9 @@ export default function AttributeCreateForm() {
   }
 
   const handleSubmit = async (attributeFormData: AttributeFormData) => {
+    // form validation
+    if (!attributeFormData.name) return
+
     await fetch('/api/attributes', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -35,6 +38,7 @@ export default function AttributeCreateForm() {
             : attributeFormData.valueType,
       }),
     })
+    
     await router.push('/settings/attributes')
   }
 

--- a/pages/settings/attributes/create.tsx
+++ b/pages/settings/attributes/create.tsx
@@ -1,0 +1,47 @@
+import {
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+} from '@mui/material'
+import UpsertAttributeForm from 'components/UpsertAttributeForm'
+import { AttributeFormData } from 'components/UpsertAttributeForm'
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+
+export default function CreateNewAttributePage() {
+  const [attributeFormData, setAttributeFormData] = useState<AttributeFormData>(
+    {} as AttributeFormData
+  )
+
+  const router = useRouter()
+
+  const handleClose = () => {
+    router.push('/settings/attributes')
+  }
+
+  const handleSubmit = async (attributeFormData: AttributeFormData) => {
+    // TODO: create post request with form data
+  }
+
+  return (
+    <>
+      <DialogTitle>Create Attribute</DialogTitle>
+      <DialogContent>
+        <UpsertAttributeForm
+          onChange={(attributeFormData) =>
+            setAttributeFormData(attributeFormData)
+          }
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} color="inherit">
+          Cancel
+        </Button>
+        <Button onClick={() => handleSubmit(attributeFormData)} color="primary">
+          Submit
+        </Button>
+      </DialogActions>
+    </>
+  )
+}

--- a/pages/settings/attributes/create.tsx
+++ b/pages/settings/attributes/create.tsx
@@ -8,8 +8,10 @@ import UpsertAttributeForm from 'components/UpsertAttributeForm'
 import { AttributeFormData } from 'components/UpsertAttributeForm'
 import { useState } from 'react'
 import { useRouter } from 'next/router'
+import { LoadingButton } from '@mui/lab'
 
-export default function CreateNewAttributePage() {
+export default function AttributeCreateForm() {
+  const [loading, setLoading] = useState(false)
   const [attributeFormData, setAttributeFormData] = useState<AttributeFormData>(
     {} as AttributeFormData
   )
@@ -21,7 +23,19 @@ export default function CreateNewAttributePage() {
   }
 
   const handleSubmit = async (attributeFormData: AttributeFormData) => {
-    // TODO: create post request with form data
+    await fetch('/api/attributes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: attributeFormData.name,
+        color: attributeFormData.color,
+        possibleValues:
+          attributeFormData.valueType === 'list'
+            ? attributeFormData.listOptions
+            : attributeFormData.valueType,
+      }),
+    })
+    await router.push('/settings/attributes')
   }
 
   return (
@@ -38,9 +52,16 @@ export default function CreateNewAttributePage() {
         <Button onClick={handleClose} color="inherit">
           Cancel
         </Button>
-        <Button onClick={() => handleSubmit(attributeFormData)} color="primary">
+        <LoadingButton
+          loading={loading}
+          onClick={async () => {
+            setLoading(true)
+            await handleSubmit(attributeFormData)
+            setLoading(false)
+          }}
+        >
           Submit
-        </Button>
+        </LoadingButton>
       </DialogActions>
     </>
   )

--- a/pages/settings/attributes/create.tsx
+++ b/pages/settings/attributes/create.tsx
@@ -51,6 +51,9 @@ export default function AttributeCreateForm() {
       }),
     })
 
+    // close dialog
+    await router.push('/settings/attributes')
+
     // handle snackbar logic
     const data = await response.json()
     if (data.success) {
@@ -68,9 +71,6 @@ export default function AttributeCreateForm() {
         })
       )
     }
-
-    // close dialog
-    await router.push('/settings/attributes')
   }
 
   return (

--- a/pages/settings/attributes/index.tsx
+++ b/pages/settings/attributes/index.tsx
@@ -17,6 +17,7 @@ import RoutableDialog from 'components/RoutableDialog'
 import AttributeEditForm from 'pages/settings/attributes/[attributeId]/edit'
 import React from 'react'
 import DialogLink from 'components/DialogLink'
+import AttributeCreateForm from 'pages/settings/attributes/create'
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   return {
@@ -68,8 +69,13 @@ export default function AttributesPage({ attributes }: AttributesPageProps) {
           />
         </Grid2>
       </Grid2>
+
+      {/* These RoutableDialogs provide functionality to buttons that open dialogs */}
       <RoutableDialog name="editAttribute">
         <AttributeEditForm />
+      </RoutableDialog>
+      <RoutableDialog name="createAttribute">
+        <AttributeCreateForm />
       </RoutableDialog>
     </>
   )

--- a/pages/settings/attributes/index.tsx
+++ b/pages/settings/attributes/index.tsx
@@ -16,6 +16,7 @@ import theme from 'utils/theme'
 import RoutableDialog from 'components/RoutableDialog'
 import AttributeEditForm from 'pages/settings/attributes/[attributeId]/edit'
 import React from 'react'
+import DialogLink from 'components/DialogLink'
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   return {
@@ -49,13 +50,15 @@ export default function AttributesPage({ attributes }: AttributesPageProps) {
             <SearchField />
           </Grid2>
           <Grid2 ml={isMobileView ? '' : 'auto'}>
-            <Button
-              variant="outlined"
-              startIcon={<AddIcon />}
-              sx={{ width: '100%' }}
-            >
-              Create New Attribute
-            </Button>
+            <DialogLink href="/settings/attributes/create">
+              <Button
+                variant="outlined"
+                startIcon={<AddIcon />}
+                sx={{ width: '100%' }}
+              >
+                Create New Attribute
+              </Button>
+            </DialogLink>
           </Grid2>
         </Grid2>
         <Grid2 xs={12} sx={{ px: isMobileView ? 0 : 2 }}>

--- a/utils/constants/dialogRoutes.ts
+++ b/utils/constants/dialogRoutes.ts
@@ -9,6 +9,10 @@ export const dialogRoutes: DialogRoute[] = [
     path: '/settings/attributes/:id/edit',
   },
   {
+    name: 'createAttribute',
+    path: '/settings/attributes/create',
+  },
+  {
     name: 'createItem',
     path: '/items/new',
   },


### PR DESCRIPTION
Can now add attributes on settings page
Misc. stuff:
- added loading button on create new attribute button and edit attribute kebab option
- Can't create an attribute with no name (which threw you into an infinite loading button)

Not covered
- Something to tell the user that their attribute with no name didn't get made (how should I go about this, a snackbar?)