### PR TITLE
Sort category table by lowercase string

### DIFF
--- a/components/CategoryList/index.tsx
+++ b/components/CategoryList/index.tsx
@@ -64,7 +64,10 @@ const headCells: readonly HeadCell[] = [
     label: 'Name',
     sortable: true,
     sortFn: (category1: CategoryResponse, category2: CategoryResponse) => {
-      return comparator(category1.name, category2.name)
+      return comparator(
+        category1.name.toLowerCase(),
+        category2.name.toLowerCase()
+      )
     },
   },
   {


### PR DESCRIPTION
previously, 'admin' would be sorted after 'Clothing' because the sort was case sensitive 