### PR TITLE
fix undefined item query on check in page

### DIFF
--- a/pages/checkIn.tsx
+++ b/pages/checkIn.tsx
@@ -187,8 +187,10 @@ export default function CheckInPage({
       </Grid2>
       <RoutableDialog>
         <NewItemPage
-          redirectBack={async (router, itemId) => {
-            await router.push(`${urls.pages.checkIn}?item=${itemId}`)
+          redirectBack={async (router, itemId?) => {
+            if (itemId)
+              await router.push(`${urls.pages.checkIn}?item=${itemId}`)
+            else await router.push(urls.pages.checkIn)
           }}
         />
       </RoutableDialog>


### PR DESCRIPTION
Per Jira:
If you click on Create New Item on the check in page and then click the “Cancel”  button, the query will contain `item=undefined`

This PR fixes this issue.