### PR TITLE
CCAHT 194 make item attribute page sorting case-insensitive

### DIFF
--- a/components/AttributeList/index.tsx
+++ b/components/AttributeList/index.tsx
@@ -64,7 +64,7 @@ const headCells: readonly HeadCell[] = [
     label: 'Attribute Name',
     sortable: true,
     sortFn(a, b) {
-      return comparator(a.name, b.name)
+      return comparator(a.name.toLowerCase(), b.name.toLowerCase())
     },
   },
   {
@@ -183,7 +183,7 @@ export default function AttributeList({
       newTableData = [
         ...newTableData.filter((attribute) => {
           return (
-            attribute.name.toLowerCase().includes(search) ||
+            attribute.name.toLowerCase().includes(lowercaseSearch) ||
             (typeof attribute.possibleValues === 'string' &&
               attribute.possibleValues.includes(lowercaseSearch)) ||
             (typeof attribute.possibleValues === 'object' &&

--- a/pages/settings/attributes/[attributeId]/edit.tsx
+++ b/pages/settings/attributes/[attributeId]/edit.tsx
@@ -59,19 +59,22 @@ export default function AttributeEditDialog() {
         return
       }
       // update attribute
-      const response = await fetch(urls.api.attributes.attribute(id![0]), {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          _id: id,
-          name: attributeFormData.name,
-          color: attributeFormData.color,
-          possibleValues:
-            attributeFormData.valueType === 'list'
-              ? attributeFormData.listOptions
-              : attributeFormData.valueType,
-        }),
-      })
+      const response = await fetch(
+        urls.api.attributes.attribute(id as string),
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            _id: id,
+            name: attributeFormData.name,
+            color: attributeFormData.color,
+            possibleValues:
+              attributeFormData.valueType === 'list'
+                ? attributeFormData.listOptions
+                : attributeFormData.valueType,
+          }),
+        }
+      )
       // handle snackbar logic
       const data = await response.json()
 

--- a/pages/settings/attributes/create.tsx
+++ b/pages/settings/attributes/create.tsx
@@ -53,7 +53,7 @@ export default function AttributeCreateDialog() {
     })
 
     // close dialog
-    await router.push(urls.api.attributes.attributes)
+    await router.push(urls.pages.settings.attributes)
 
     // handle snackbar logic
     const data = await response.json()


### PR DESCRIPTION
This makes the table sorting case insensitive
However, I noticed a lot more issues on the attributes page
1. The search wasn't taking into account lowercase names for some reason (FIXED)
2. The create button sent you to the api endpoint instead of the settings page when you hit submit (FIXED)
3. Creating an attribute does not make it appear on the page right away (it used to a while ago, idk what changed) (NOT FIXED)
4. Editing an attribute is now broken because zod thinks the objectId isn't valid (?) (NOT FIXED)