### PR TITLE
CCAHT-243 coloring and spacing on attribute list items

### DIFF
--- a/components/AttributeList/AttributeListItem/index.tsx
+++ b/components/AttributeList/AttributeListItem/index.tsx
@@ -3,6 +3,7 @@ import CircleIcon from '@mui/icons-material/Circle'
 import { AttributeResponse } from 'utils/types'
 import AttributeListItemKebab from '../AttributeListItemKebab'
 import React from 'react'
+import getContrastYIQ from 'utils/getContrastYIQ'
 
 interface AttributeListItemProps {
   attribute: AttributeResponse
@@ -11,11 +12,6 @@ interface AttributeListItemProps {
 export default function AttributeListItem({
   attribute,
 }: AttributeListItemProps) {
-  // React.useEffect(() => {
-  //   if (attribute.name === 'Oven Type') {
-  //     console.log(attribute)
-  //   }
-  // }, [attribute])
   return (
     <TableRow>
       <TableCell>{attribute.name}</TableCell>
@@ -26,6 +22,13 @@ export default function AttributeListItem({
                 size="small"
                 label={possibleValue}
                 key={`${possibleValue}-${index}`}
+                sx={{
+                  mr: 1,
+                  backgroundColor: attribute.color,
+                  '& .MuiChip-label': {
+                    color: getContrastYIQ(attribute.color),
+                  },
+                }}
               />
             ))
           : attribute.possibleValues.charAt(0).toUpperCase() +

--- a/components/AttributeList/AttributeListItem/index.tsx
+++ b/components/AttributeList/AttributeListItem/index.tsx
@@ -24,6 +24,7 @@ export default function AttributeListItem({
                 key={`${possibleValue}-${index}`}
                 sx={{
                   mr: 1,
+                  my: 0.5,
                   backgroundColor: attribute.color,
                   '& .MuiChip-label': {
                     color: getContrastYIQ(attribute.color),

--- a/components/AttributeList/index.tsx
+++ b/components/AttributeList/index.tsx
@@ -149,7 +149,7 @@ interface AttributeListProps {
   search: string
 }
 
-const DEFAULT_ROWS_PER_PAGE = 5
+const DEFAULT_ROWS_PER_PAGE = 10
 const DEFAULT_ORDER_BY = 'name'
 const DEFAULT_ORDER = 'asc'
 

--- a/components/CategoryList/index.tsx
+++ b/components/CategoryList/index.tsx
@@ -133,7 +133,7 @@ interface Props {
   search: string
 }
 
-const DEFAULT_ROWS_PER_PAGE = 5
+const DEFAULT_ROWS_PER_PAGE = 10
 const DEFAULT_ORDER_BY = 'name'
 const DEFAULT_ORDER = 'asc'
 

--- a/components/ItemDefinitionList/DesktopItemDefinitionList/index.tsx
+++ b/components/ItemDefinitionList/DesktopItemDefinitionList/index.tsx
@@ -182,7 +182,7 @@ type Order = 'asc' | 'desc'
 // Constants
 const DEFAULT_ORDER: Order = 'asc'
 const DEFAULT_ORDER_BY: HeadKey = 'name'
-const DEFAULT_ROWS_PER_PAGE = 5
+const DEFAULT_ROWS_PER_PAGE = 10
 
 export default function ItemDefinitionList({
   itemDefinitions,

--- a/pages/settings/attributes/index.tsx
+++ b/pages/settings/attributes/index.tsx
@@ -47,22 +47,13 @@ export default function AttributesPage({ attributes }: AttributesPageProps) {
             </DialogLink>
           </Grid2>
         </Grid2>
-        <Grid2
-          container
-          xs={12}
-          gap={isMobileView ? 2 : 0}
-          sx={{ px: 2, xs: 12, md: 4 }}
-        >
-          <Grid2 xs={12} md={4}>
-            <SearchField />
-          </Grid2>
+        <Grid2 xs={12} md={5} lg={4} sx={{ px: 2 }}>
+          <SearchField />
         </Grid2>
-        <Grid2 xs={12} sx={{ px: isMobileView ? 0 : 2 }}>
-          <AttributeList
-            attributes={attributes}
-            search={router.query.search as string}
-          />
-        </Grid2>
+        <AttributeList
+          attributes={attributes}
+          search={router.query.search as string}
+        />
       </Grid2>
 
       {/* These RoutableDialogs provide functionality to buttons that open dialogs */}

--- a/pages/settings/categories/index.tsx
+++ b/pages/settings/categories/index.tsx
@@ -29,12 +29,12 @@ export default function CategoriesPage({ categories }: CategoriesPageProps) {
   const isMobileView = useMediaQuery(theme.breakpoints.down('md'))
   return (
     <>
-      <Grid2 container my={2} sx={{ flexGrow: 1, px: 2 }} gap={2}>
+      <Grid2 container my={2} sx={{ flexGrow: 1 }} gap={2}>
         <Grid2 xs={12} container direction={'row'}>
           <Typography variant="h5" sx={{ mb: 2, ml: 2 }}>
             Categories
           </Typography>
-          <Grid2 ml={isMobileView ? '0' : 'auto'}>
+          <Grid2 ml="auto" mr={isMobileView ? 2 : 6}>
             <DialogLink href={urls.pages.dialogs.createCategory}>
               <Button variant="outlined" sx={{ width: '100%' }}>
                 Create New Category

--- a/pages/settings/items/index.tsx
+++ b/pages/settings/items/index.tsx
@@ -37,7 +37,7 @@ export default function ItemsPage({ itemDefinitions }: Props) {
 
   return (
     <>
-      <Grid2 container my={2} sx={{ flexGrow: 1, px: 2 }} gap={2}>
+      <Grid2 container my={2} sx={{ flexGrow: 1 }} gap={2}>
         <Grid2 xs={12} container direction={'row'}>
           <Typography variant="h5" sx={{ mb: 2, ml: 2 }}>
             Items


### PR DESCRIPTION
- CCAHT-243 only pertains to `components/AttributeList/AttributeListItem/index.tsx`
- `my: 0.5` is there for mobile view. It's probable you can make a reusable function when working on the mobile view

Forgot to switch branches when completing [CCAHT-232](https://team-16679321250140.atlassian.net/browse/CCAHT-232). Third and fourth commits on this PR are for that story, and that PR description is as follows:
- I updated the default pagination on the settings pages to 10 so that the appearance of a scrollbar isn't jarring when switching between settings and backend-paginated tables. Feel free to revert if you disagree.
- It didn't make sense to do this one and NOT [CCAHT-235](https://team-16679321250140.atlassian.net/browse/CCAHT-235), so please move both CCAHT-235 and CCAHT-232 to done if you decide to merge these

[CCAHT-232]: https://team-16679321250140.atlassian.net/browse/CCAHT-232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CCAHT-235]: https://team-16679321250140.atlassian.net/browse/CCAHT-235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ