### PR TITLE
CCAHT-271 increased debounce time to 550

### DIFF
--- a/components/SearchField/index.tsx
+++ b/components/SearchField/index.tsx
@@ -14,7 +14,7 @@ const updateSearchQuery = (search: string, router: NextRouter) => {
   else addURLQueryParam(router, 'search', search)
 }
 
-const debouncedUpdateSearchQuery = debounce(updateSearchQuery, 300)
+const debouncedUpdateSearchQuery = debounce(updateSearchQuery, 550)
 
 export default function SearchField() {
   const { router } = useRouterQuery()
@@ -32,21 +32,24 @@ export default function SearchField() {
       fullWidth
       endAdornment={
         <>
-        { search &&
-          <InputAdornment position='end'>
-            <IconButton size='small' sx={{ p: 0 }} onClick={() => onChange("")}>
-              <Close fontSize='small' />
-            </IconButton>
+          {search && (
+            <InputAdornment position="end">
+              <IconButton
+                size="small"
+                sx={{ p: 0 }}
+                onClick={() => onChange('')}
+              >
+                <Close fontSize="small" />
+              </IconButton>
+            </InputAdornment>
+          )}
+          <InputAdornment position="end">
+            <Search />
           </InputAdornment>
-        }
-        <InputAdornment position="end">
-          <Search />
-        </InputAdornment>
         </>
       }
       onChange={(e) => onChange(e.target.value)}
       value={search}
-      
     ></OutlinedInput>
   )
 }

--- a/components/SearchField/index.tsx
+++ b/components/SearchField/index.tsx
@@ -14,7 +14,7 @@ const updateSearchQuery = (search: string, router: NextRouter) => {
   else addURLQueryParam(router, 'search', search)
 }
 
-const debouncedUpdateSearchQuery = debounce(updateSearchQuery, 550)
+const debouncedUpdateSearchQuery = debounce(updateSearchQuery, 600)
 
 export default function SearchField() {
   const { router } = useRouterQuery()


### PR DESCRIPTION
So that holding down backspace doesn't trigger another database call before the backspace key starts repeating. Default character repeat delay on windows and iphone is 500, and 300 on android. Setting it at 501 didn't quite work, so up to 550 it is. 

The only change I made is the debounce delay, all other changes in the file are from prettier.