### PR TITLE
CCAHT-276 fix spaces in critically low stock email url

### DIFF
--- a/server/actions/InventoryItems.ts
+++ b/server/actions/InventoryItems.ts
@@ -449,8 +449,10 @@ View here: ${process.env.NEXTAUTH_URL}${
     urls.pages.inventory
   }${constructQueryString(
     {
-      search: inventoryItem.itemDefinition.name,
-      category: inventoryItem.itemDefinition.category?.name || '',
+      search: encodeURIComponent(inventoryItem.itemDefinition.name),
+      category: encodeURIComponent(
+        inventoryItem.itemDefinition.category?.name || ''
+      ),
       orderBy: 'quantity',
     },
     true


### PR DESCRIPTION
Previously if there was a space in a field it would break the url and make it not clickable