### PR TITLE
CCAHT-227 Fix Zod validation fail on checkin/out from prefilled form with item name with more than one word

### DIFF
--- a/pages/checkIn.tsx
+++ b/pages/checkIn.tsx
@@ -97,6 +97,11 @@ export default function CheckInPage({
   }, [formData.itemDefinition])
 
   const onSubmit = async (formData: CheckInOutFormData) => {
+    // necessary for navigation from kebab, which encodes assignee as null
+    if (formData.assignee === null) {
+      formData.assignee = undefined
+    }
+
     const res = checkInOutFormSchema.safeParse(formData)
 
     if (!res.success) {

--- a/pages/checkOut.tsx
+++ b/pages/checkOut.tsx
@@ -81,6 +81,11 @@ export default function CheckOutPage({
   }, [formData.itemDefinition])
 
   const onSubmit = async (formData: CheckInOutFormData) => {
+    // necessary for navigation from kebab, which encodes assignee as null
+    if (formData.assignee === null) {
+      formData.assignee = undefined
+    }
+
     const res = checkInOutFormSchema.safeParse(formData)
 
     if (!res.success) {


### PR DESCRIPTION
God knows how I found this bug. Test by commenting out the fix and observing that you cannot check in/out shaving cream or vacuum cleaners (but for some reason you can with body wash? but it used to not work) if you navigate to checkin/out from a kebab, then, uncomment the solution and observe you can check in/out that item now.

Issue was that `"assignee": null` was sometimes getting encoded in the url. I don't know why it only happens sometimes.