### PR TITLE
Auth email domain restriction

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -28,11 +28,12 @@ export const authOptions: NextAuthOptions = {
       if (
         account?.provider === 'google' &&
         (profile?.email?.endsWith('@ccaht.org') ||
-          allowedEmails?.includes(profile?.email || ''))
+          allowedEmails?.includes(profile?.email!))
       ) {
         return profile?.email_verified
+      } else {
+        return false
       }
-      return true
     },
     // modifies the session returned to have the user's id. to find this, we use the token.sub which is the subject of the token.
     async session({ session, token }) {


### PR DESCRIPTION
Seems obvious in hindsight, we were returning true if they were a disallowed email :)
Also removed the `|| ''` fallback value in the `.includes`. Don't think it's a present issue, but if a env file happens to have `,,` in it and someone somehow logs in with a google profile without an email, it would let them through. No errors are thrown if `.includes` gets null or undefined, so this just adds a little more confidence.

Tested by:
- Attempting to sign in with any email
- Attempting to sign in with an email on the ALLOWED_EMAILS env property (nice touch whoever put that in!)
- Changing '@ccaht.org' to '@vols.utk.edu' and verifying that I could log in with my school email but not others
