### PR TITLE
add no refresh delete to inventory

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,10 +1,10 @@
-name: Node.js CI
+name: Lint App
 
 on:
   pull_request:
 
 jobs:
-  test:
+  lint:
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout repo

--- a/components/InventoryItemList/InventoryItemContext.tsx
+++ b/components/InventoryItemList/InventoryItemContext.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { createContext } from 'react'
+
+export type InventoryItemContextType = {
+  refetch: () => void
+}
+
+export const InventoryItemContext =
+  createContext<InventoryItemContextType | null>(null)
+
+type InventoryItemProviderProps = {
+  refetch: () => void
+  children: React.ReactNode
+}
+
+const InventoryItemProvider = ({
+  refetch,
+  children,
+}: InventoryItemProviderProps) => {
+  return (
+    <InventoryItemContext.Provider value={{ refetch }}>
+      {children}
+    </InventoryItemContext.Provider>
+  )
+}
+
+export default InventoryItemProvider

--- a/components/InventoryItemList/InventoryItemListItemKebab/index.tsx
+++ b/components/InventoryItemList/InventoryItemListItemKebab/index.tsx
@@ -90,7 +90,6 @@ export default function InventoryItemListItemKebab({
           fetch(urls.api.inventoryItems.inventoryItem(inventoryItem._id), {
             method: 'DELETE',
           }).then(() => {
-            // window.location.reload()
             refetch()
             // @ts-ignore
             dispatch(

--- a/components/InventoryItemList/InventoryItemListItemKebab/index.tsx
+++ b/components/InventoryItemList/InventoryItemListItemKebab/index.tsx
@@ -8,6 +8,10 @@ import { showSnackbar } from 'store/snackbar'
 import { useAppDispatch } from 'store'
 import urls from 'utils/urls'
 import { dialogPush } from 'utils/dialogLink'
+import {
+  InventoryItemContext,
+  InventoryItemContextType,
+} from '../InventoryItemContext'
 
 interface InventoryItemListItemKebabOption {
   name: string
@@ -21,6 +25,9 @@ interface InventoryItemListItemKebabProps {
 export default function InventoryItemListItemKebab({
   inventoryItem,
 }: InventoryItemListItemKebabProps) {
+  const { refetch } = React.useContext(
+    InventoryItemContext
+  ) as InventoryItemContextType
   // kebab menu functionality
   const [anchorElKebab, setAnchorElKebab] = React.useState<null | HTMLElement>(
     null
@@ -83,7 +90,8 @@ export default function InventoryItemListItemKebab({
           fetch(urls.api.inventoryItems.inventoryItem(inventoryItem._id), {
             method: 'DELETE',
           }).then(() => {
-            window.location.reload()
+            // window.location.reload()
+            refetch()
             // @ts-ignore
             dispatch(
               showSnackbar({

--- a/components/InventoryItemList/index.tsx
+++ b/components/InventoryItemList/index.tsx
@@ -3,6 +3,7 @@ import DesktopInventoryItemList from 'components/InventoryItemList/DesktopInvent
 import MobileInventoryItemList from 'components/InventoryItemList/MobileInventoryItemList'
 import React from 'react'
 import { InventoryItemResponse } from 'utils/types'
+import InventoryItemProvider from './InventoryItemContext'
 
 interface InventoryItemListProps {
   inventoryItems: InventoryItemResponse[]
@@ -10,6 +11,7 @@ interface InventoryItemListProps {
   category: string
   total: number
   loading: boolean
+  refetch: () => void
 }
 
 export default function InventoryItemList({
@@ -18,11 +20,12 @@ export default function InventoryItemList({
   category,
   total,
   loading,
+  refetch,
 }: InventoryItemListProps) {
   const theme = useTheme()
   const isMobileView = useMediaQuery(theme.breakpoints.down('md'))
   return (
-    <>
+    <InventoryItemProvider refetch={refetch}>
       {isMobileView ? (
         <MobileInventoryItemList
           inventoryItems={inventoryItems}
@@ -40,6 +43,6 @@ export default function InventoryItemList({
           loading={loading}
         />
       )}
-    </>
+    </InventoryItemProvider>
   )
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cchat",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/pages/inventory.tsx
+++ b/pages/inventory.tsx
@@ -165,6 +165,7 @@ export default function InventoryPage({ categories }: Props) {
           category={router.query.category as string}
           total={total}
           loading={loading}
+          refetch={refetch}
         />
       </Grid2>
       <RoutableDialog name="assignItem">


### PR DESCRIPTION
Simple. Added a context to allow the kebab component to access a `refetch` method without prop drilling. To test, go in to inventory and delete an item. skeleton loaders should appear to show that the app is refetching the data, and no full page reload should occur

ALSO:
fix workflow file for linting for better naming
bump version 