### PR TITLE
add logging utilities to soft deletion and assignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cchat",
-  "version": "1.1.5",
+  "version": "1.1.7",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/pages/api/itemDefinitions/[itemDefinitionId]/index.ts
+++ b/pages/api/itemDefinitions/[itemDefinitionId]/index.ts
@@ -13,6 +13,7 @@ import {
 import * as MongoDriver from 'server/actions/MongoDriver'
 import ItemDefinitionSchema from 'server/models/ItemDefinition'
 import { errors } from 'utils/constants/errors'
+import { logSoftDeletion } from 'utils/log'
 
 // @route GET api/itemDefintions/[itemDefinitionId] - Returns a single ItemDefinition object given a itemDefinitionId - Private
 // @route PUT api/users/[itemDefinitionId] - Updates an existing ItemDefinition object (identified by itemDefinitionId) with a new ItemDefinition object - Private
@@ -23,7 +24,7 @@ export default async function itemDefinitionHandler(
 ) {
   try {
     // ensure user is logged in
-    await serverAuth(req, res)
+    const { user } = await serverAuth(req, res)
 
     apiObjectIdValidation(req?.query?.itemDefinitionId as string)
     const itemDefinitionId = req.query.itemDefinitionId as string
@@ -53,10 +54,13 @@ export default async function itemDefinitionHandler(
         })
       }
       case 'DELETE': {
-        await MongoDriver.softDeleteEntity(
+        const itemDef = await MongoDriver.softDeleteEntity(
           ItemDefinitionSchema,
           itemDefinitionId
         )
+
+        // log action
+        logSoftDeletion(user, itemDef)
 
         return res.status(200).json({
           success: true,

--- a/server/actions/InventoryItems.ts
+++ b/server/actions/InventoryItems.ts
@@ -437,14 +437,14 @@ export async function setAssignee(
 ) {
   if (assigneeId) {
     apiObjectIdValidation(assigneeId)
-    await InventoryItemSchema.findByIdAndUpdate(inventoryItemId, {
+    return await InventoryItemSchema.findByIdAndUpdate(inventoryItemId, {
       assignee: assigneeId,
     }).catch((err) => {
       console.error(err)
       throw new ApiError(500, errors.serverError)
     })
   } else {
-    await InventoryItemSchema.findByIdAndUpdate(inventoryItemId, {
+    return await InventoryItemSchema.findByIdAndUpdate(inventoryItemId, {
       $unset: { assignee: 1 },
     }).catch((err) => {
       console.error(err)

--- a/server/actions/ItemDefinition.ts
+++ b/server/actions/ItemDefinition.ts
@@ -1,5 +1,4 @@
 import ItemDefinitionSchema from 'server/models/ItemDefinition'
-import InventoryItemSchema from 'server/models/InventoryItem'
 import { getEntities, getEntity } from 'server/actions/MongoDriver'
 import {
   InventoryItemExistingAttributeValuesResponse,

--- a/server/actions/MongoDriver.ts
+++ b/server/actions/MongoDriver.ts
@@ -143,13 +143,15 @@ export async function deleteEntity<Schema extends Document>(
 export async function softDeleteEntity<Schema extends Document>(
   dbSchema: Model<Schema>,
   id: string
-): Promise<void> {
+): Promise<HydratedDocument<Schema, unknown, unknown>> {
   await mongoDb()
 
   const response = await dbSchema.findByIdAndUpdate(id, { softDelete: true })
   if (!response) {
     throw new ApiError(404, errors.notFound)
   }
+
+  return response
 }
 
 /**

--- a/test/api/appConfigs/[appConfigId].test.ts
+++ b/test/api/appConfigs/[appConfigId].test.ts
@@ -13,9 +13,12 @@ import {
   validAppConfigPutRequest,
 } from 'test/testData'
 import urls from 'utils/urls'
+import { serverAuthMock } from 'test/helpers/serverAuth'
 
 beforeAll(() => {
-  jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
+  jest
+    .spyOn(auth, 'serverAuth')
+    .mockImplementation(() => Promise.resolve(serverAuthMock))
   jest.spyOn(apiValidator, 'apiObjectIdValidation').mockImplementation()
 })
 

--- a/test/api/appConfigs/index.test.ts
+++ b/test/api/appConfigs/index.test.ts
@@ -13,9 +13,12 @@ import {
   validAppConfigPostRequest,
 } from 'test/testData'
 import urls from 'utils/urls'
+import { serverAuthMock } from 'test/helpers/serverAuth'
 
 beforeAll(() => {
-  jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
+  jest
+    .spyOn(auth, 'serverAuth')
+    .mockImplementation(() => Promise.resolve(serverAuthMock))
 })
 
 // restore mocked implementations and close db connections
@@ -67,7 +70,7 @@ describe('api/appConfigs', () => {
     test('valid call returns correct data', async () => {
       const serverAuth = jest
         .spyOn(auth, 'serverAuth')
-        .mockImplementation(() => Promise.resolve())
+        .mockImplementation(() => Promise.resolve(serverAuthMock))
       const mockGetEntities = jest
         .spyOn(MongoDriver, 'getEntities')
         .mockImplementation(

--- a/test/api/attributes/[attributeId].test.ts
+++ b/test/api/attributes/[attributeId].test.ts
@@ -150,10 +150,13 @@ describe('api/attributes/[attributeId]', () => {
         .spyOn(MongoDriver, 'softDeleteEntity')
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         .mockImplementation(
-          async () => ({} as ReturnType<typeof MongoDriver.softDeleteEntity>)
+          async () =>
+            ({ collection: { collectionName: 'attributes' } } as Awaited<
+              ReturnType<typeof MongoDriver.softDeleteEntity>
+            >)
         )
 
-      const mockGetAppConfig = jest
+      jest
         .spyOn(AppConfigActions, 'getAppConfigs')
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         .mockImplementation(async () => validAppConfigResponse)

--- a/test/api/attributes/[attributeId].test.ts
+++ b/test/api/attributes/[attributeId].test.ts
@@ -16,9 +16,12 @@ import {
 } from 'test/testData'
 import urls from 'utils/urls'
 import * as AppConfigActions from 'server/actions/AppConfig'
+import { serverAuthMock } from 'test/helpers/serverAuth'
 
 beforeAll(() => {
-  jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
+  jest
+    .spyOn(auth, 'serverAuth')
+    .mockImplementation(() => Promise.resolve(serverAuthMock))
 
   jest.spyOn(apiValidator, 'apiObjectIdValidation').mockImplementation()
 })
@@ -146,7 +149,9 @@ describe('api/attributes/[attributeId]', () => {
       const mockDeleteEntity = jest
         .spyOn(MongoDriver, 'softDeleteEntity')
         // eslint-disable-next-line @typescript-eslint/no-empty-function
-        .mockImplementation(async () => {})
+        .mockImplementation(
+          async () => ({} as ReturnType<typeof MongoDriver.softDeleteEntity>)
+        )
 
       const mockGetAppConfig = jest
         .spyOn(AppConfigActions, 'getAppConfigs')

--- a/test/api/attributes/index.test.ts
+++ b/test/api/attributes/index.test.ts
@@ -10,9 +10,12 @@ import mongoose from 'mongoose'
 import { errors } from 'utils/constants/errors'
 import { validAttributeResponse, mockObjectId } from 'test/testData'
 import urls from 'utils/urls'
+import { serverAuthMock } from 'test/helpers/serverAuth'
 
 beforeAll(() => {
-  jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
+  jest
+    .spyOn(auth, 'serverAuth')
+    .mockImplementation(() => Promise.resolve(serverAuthMock))
 })
 
 // restore mocked implementations and close db connections
@@ -65,7 +68,7 @@ describe('api/attributes', () => {
     test('valid call returns correct data', async () => {
       const serverAuth = jest
         .spyOn(auth, 'serverAuth')
-        .mockImplementation(() => Promise.resolve())
+        .mockImplementation(() => Promise.resolve(serverAuthMock))
       const mockGetEntities = jest
         .spyOn(MongoDriver, 'findEntitiesByQuery')
         .mockImplementation(

--- a/test/api/categories/[categoryId].test.ts
+++ b/test/api/categories/[categoryId].test.ts
@@ -149,7 +149,12 @@ describe('api/categories/[categoryId]', () => {
       const mockDeleteEntity = jest
         .spyOn(MongoDriver, 'softDeleteEntity')
         // eslint-disable-next-line @typescript-eslint/no-empty-function
-        .mockImplementation(async () => {})
+        .mockImplementation(
+          async () =>
+            ({ collection: { collectionName: 'categories' } } as Awaited<
+              ReturnType<typeof MongoDriver.softDeleteEntity>
+            >)
+        )
       const request = createRequest({
         method: 'DELETE',
         url: urls.api.categories.category(mockObjectId),

--- a/test/api/categories/[categoryId].test.ts
+++ b/test/api/categories/[categoryId].test.ts
@@ -14,9 +14,12 @@ import {
   validCategoryPutRequest,
 } from 'test/testData'
 import urls from 'utils/urls'
+import { serverAuthMock } from 'test/helpers/serverAuth'
 
 beforeAll(() => {
-  jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
+  jest
+    .spyOn(auth, 'serverAuth')
+    .mockImplementation(() => Promise.resolve(serverAuthMock))
 
   jest.spyOn(apiValidator, 'apiObjectIdValidation').mockImplementation()
 })

--- a/test/api/categories/index.test.ts
+++ b/test/api/categories/index.test.ts
@@ -14,9 +14,12 @@ import {
   validCategoryPostRequest,
 } from 'test/testData'
 import urls from 'utils/urls'
+import { serverAuthMock } from 'test/helpers/serverAuth'
 
 beforeAll(() => {
-  jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
+  jest
+    .spyOn(auth, 'serverAuth')
+    .mockImplementation(() => Promise.resolve(serverAuthMock))
 })
 
 // restore mocked implementations and close db connections
@@ -69,7 +72,7 @@ describe('api/categories', () => {
     test('valid call returns correct data', async () => {
       const serverAuth = jest
         .spyOn(auth, 'serverAuth')
-        .mockImplementation(() => Promise.resolve())
+        .mockImplementation(() => Promise.resolve(serverAuthMock))
       const mockGetEntities = jest
         .spyOn(MongoDriver, 'findEntitiesByQuery')
         .mockImplementation(

--- a/test/api/inventoryItems/[inventoryItemId].test.ts
+++ b/test/api/inventoryItems/[inventoryItemId].test.ts
@@ -16,12 +16,15 @@ import {
   validInventoryItemPutRequest,
 } from 'test/testData'
 import urls from 'utils/urls'
+import { serverAuthMock } from 'test/helpers/serverAuth'
 
 // TODO: add assertion for GET 'called with' aggregate stuff
 // this may need to have different functionality
 
 beforeAll(() => {
-  jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
+  jest
+    .spyOn(auth, 'serverAuth')
+    .mockImplementation(() => Promise.resolve(serverAuthMock))
   jest.spyOn(apiValidator, 'apiObjectIdValidation').mockImplementation()
 })
 

--- a/test/api/inventoryItems/[inventoryItemId].test.ts
+++ b/test/api/inventoryItems/[inventoryItemId].test.ts
@@ -152,7 +152,12 @@ describe('api/inventoryItems/[inventoryItemId]', () => {
       const mockDeleteEntity = jest
         .spyOn(MongoDriver, 'softDeleteEntity')
         // eslint-disable-next-line @typescript-eslint/no-empty-function
-        .mockImplementation(async () => {})
+        .mockImplementation(
+          async () =>
+            ({ collection: { collectionName: 'inventory_items' } } as Awaited<
+              ReturnType<typeof MongoDriver.softDeleteEntity>
+            >)
+        )
       const request = createRequest({
         method: 'DELETE',
         url: urls.api.inventoryItems.inventoryItem(mockObjectId),

--- a/test/api/inventoryItems/checkIn.test.ts
+++ b/test/api/inventoryItems/checkIn.test.ts
@@ -17,9 +17,12 @@ import {
   validCheckInOutRequest,
 } from 'test/testData'
 import urls from 'utils/urls'
+import { serverAuthMock } from 'test/helpers/serverAuth'
 
 beforeAll(() => {
-  jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
+  jest
+    .spyOn(auth, 'serverAuth')
+    .mockImplementation(() => Promise.resolve(serverAuthMock))
 })
 
 // restore mocked implementations and close db connections

--- a/test/api/inventoryItems/index.test.ts
+++ b/test/api/inventoryItems/index.test.ts
@@ -15,9 +15,12 @@ import {
   validInventoryItemPostRequest,
 } from 'test/testData'
 import urls from 'utils/urls'
+import { serverAuthMock } from 'test/helpers/serverAuth'
 
 beforeAll(() => {
-  jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
+  jest
+    .spyOn(auth, 'serverAuth')
+    .mockImplementation(() => Promise.resolve(serverAuthMock))
 })
 
 // restore mocked implementations and close db connections
@@ -69,7 +72,7 @@ describe('api/inventoryItems', () => {
     test('valid call returns correct data', async () => {
       const serverAuth = jest
         .spyOn(auth, 'serverAuth')
-        .mockImplementation(() => Promise.resolve())
+        .mockImplementation(() => Promise.resolve(serverAuthMock))
       const mockGetEntities = jest
         .spyOn(MongoDriver, 'getEntities')
         .mockImplementation(

--- a/test/api/itemDefinitions/[itemDefinitionId]/attributeValues.test.ts
+++ b/test/api/itemDefinitions/[itemDefinitionId]/attributeValues.test.ts
@@ -11,9 +11,12 @@ import {
 } from 'test/testData'
 import ItemDefinitionSchema from 'server/models/ItemDefinition'
 import itemDefinitionAttributeValuesHandler from '@api/itemDefinitions/[itemDefinitionId]/attributeValues'
+import { serverAuthMock } from 'test/helpers/serverAuth'
 
 beforeAll(() => {
-  jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
+  jest
+    .spyOn(auth, 'serverAuth')
+    .mockImplementation(() => Promise.resolve(serverAuthMock))
   jest.spyOn(apiValidator, 'apiObjectIdValidation').mockImplementation()
 })
 

--- a/test/api/itemDefinitions/[itemDefinitionId]/index.test.ts
+++ b/test/api/itemDefinitions/[itemDefinitionId]/index.test.ts
@@ -15,12 +15,15 @@ import {
   validItemDefinitionPutRequest,
 } from 'test/testData'
 import urls from 'utils/urls'
+import { serverAuthMock } from 'test/helpers/serverAuth'
 
 // TODO: add assertion for GET 'called with' aggregate stuff
 // this may need to have different functionality
 
 beforeAll(() => {
-  jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
+  jest
+    .spyOn(auth, 'serverAuth')
+    .mockImplementation(() => Promise.resolve(serverAuthMock))
   jest.spyOn(apiValidator, 'apiObjectIdValidation').mockImplementation()
 })
 
@@ -148,7 +151,9 @@ describe('api/itemDefinitions/[itemDefinitionId]', () => {
       const mockDeleteEntity = jest
         .spyOn(MongoDriver, 'softDeleteEntity')
         // eslint-disable-next-line @typescript-eslint/no-empty-function
-        .mockImplementation(async () => {})
+        .mockImplementation(
+          async () => ({} as ReturnType<typeof MongoDriver.softDeleteEntity>)
+        )
       const request = createRequest({
         method: 'DELETE',
         url: urls.api.itemDefinitions.itemDefinition(mockObjectId),

--- a/test/api/itemDefinitions/[itemDefinitionId]/index.test.ts
+++ b/test/api/itemDefinitions/[itemDefinitionId]/index.test.ts
@@ -152,7 +152,10 @@ describe('api/itemDefinitions/[itemDefinitionId]', () => {
         .spyOn(MongoDriver, 'softDeleteEntity')
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         .mockImplementation(
-          async () => ({} as ReturnType<typeof MongoDriver.softDeleteEntity>)
+          async () =>
+            ({ collection: { collectionName: 'item_defintions' } } as Awaited<
+              ReturnType<typeof MongoDriver.softDeleteEntity>
+            >)
         )
       const request = createRequest({
         method: 'DELETE',

--- a/test/api/itemDefinitions/index.test.ts
+++ b/test/api/itemDefinitions/index.test.ts
@@ -15,9 +15,12 @@ import {
   validItemDefinitionPostRequest,
 } from 'test/testData'
 import urls from 'utils/urls'
+import { serverAuthMock } from 'test/helpers/serverAuth'
 
 beforeAll(() => {
-  jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
+  jest
+    .spyOn(auth, 'serverAuth')
+    .mockImplementation(() => Promise.resolve(serverAuthMock))
 })
 
 // restore mocked implementations and close db connections
@@ -69,7 +72,7 @@ describe('api/itemDefinitions', () => {
     test('valid call returns correct data', async () => {
       const serverAuth = jest
         .spyOn(auth, 'serverAuth')
-        .mockImplementation(() => Promise.resolve())
+        .mockImplementation(() => Promise.resolve(serverAuthMock))
       const mockGetEntities = jest
         .spyOn(MongoDriver, 'getEntities')
         .mockImplementation(

--- a/test/api/logs/[logId].test.ts
+++ b/test/api/logs/[logId].test.ts
@@ -13,12 +13,15 @@ import {
   validLogPutRequest,
 } from 'test/testData'
 import urls from 'utils/urls'
+import { serverAuthMock } from 'test/helpers/serverAuth'
 
 // TODO: add assertion for GET 'called with' aggregate stuff
 // this may need to have different functionality
 
 beforeAll(() => {
-  jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
+  jest
+    .spyOn(auth, 'serverAuth')
+    .mockImplementation(() => Promise.resolve(serverAuthMock))
   jest.spyOn(apiValidator, 'apiObjectIdValidation').mockImplementation()
 })
 

--- a/test/api/logs/index.test.ts
+++ b/test/api/logs/index.test.ts
@@ -8,9 +8,12 @@ import * as MongoDriver from 'server/actions/MongoDriver'
 import { errors } from 'utils/constants/errors'
 import { validLogResponse } from 'test/testData'
 import urls from 'utils/urls'
+import { serverAuthMock } from 'test/helpers/serverAuth'
 
 beforeAll(() => {
-  jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
+  jest
+    .spyOn(auth, 'serverAuth')
+    .mockImplementation(() => Promise.resolve(serverAuthMock))
 })
 
 // restore mocked implementations and close db connections
@@ -62,7 +65,7 @@ describe('api/logs', () => {
     test('valid call returns correct data', async () => {
       const serverAuth = jest
         .spyOn(auth, 'serverAuth')
-        .mockImplementation(() => Promise.resolve())
+        .mockImplementation(() => Promise.resolve(serverAuthMock))
       const mockGetEntities = jest
         .spyOn(MongoDriver, 'getEntities')
         .mockImplementation(

--- a/test/api/users/index.test.ts
+++ b/test/api/users/index.test.ts
@@ -14,9 +14,12 @@ import {
   validUserPostRequest,
 } from 'test/testData'
 import urls from 'utils/urls'
+import { serverAuthMock } from 'test/helpers/serverAuth'
 
 beforeAll(() => {
-  jest.spyOn(auth, 'serverAuth').mockImplementation(() => Promise.resolve())
+  jest
+    .spyOn(auth, 'serverAuth')
+    .mockImplementation(() => Promise.resolve(serverAuthMock))
 })
 
 // restore mocked implementations and close db connections
@@ -69,7 +72,7 @@ describe('api/users', () => {
     test('valid call returns correct data', async () => {
       const serverAuth = jest
         .spyOn(auth, 'serverAuth')
-        .mockImplementation(() => Promise.resolve())
+        .mockImplementation(() => Promise.resolve(serverAuthMock))
       const mockGetEntities = jest
         .spyOn(MongoDriver, 'getEntities')
         .mockImplementation(

--- a/test/helpers/serverAuth.ts
+++ b/test/helpers/serverAuth.ts
@@ -1,0 +1,11 @@
+import { Session } from 'next-auth'
+
+export const serverAuthMock: Session = {
+  user: {
+    _id: 'testid',
+    name: 'John Doe',
+    email: 'john@doe.com',
+    image: 'fakeurl.com/image',
+  },
+  expires: 'never',
+}

--- a/test/server/MongoDriver.test.ts
+++ b/test/server/MongoDriver.test.ts
@@ -204,10 +204,7 @@ describe('MongoDriver', () => {
         .fn()
         .mockImplementation(async () => [validCategoryResponse]))
 
-      const categories = await MongoDriver.softDeleteEntity(
-        CategorySchema,
-        mockObjectId
-      )
+      await MongoDriver.softDeleteEntity(CategorySchema, mockObjectId)
 
       expect(mockUpdate).toHaveBeenCalledTimes(1)
     })

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { getServerSession } from 'next-auth'
+import { Session, getServerSession } from 'next-auth'
 import { authOptions } from '@api/auth/[...nextauth]'
 import { ApiError } from 'utils/types'
 import { errors } from 'utils/constants/errors'
@@ -25,9 +25,14 @@ export async function userEndpointServerAuth(
   }
 }
 
-export async function serverAuth(req: NextApiRequest, res: NextApiResponse) {
+export async function serverAuth(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<Session> {
   const session = await getServerSession(req, res, authOptions)
   if (!session) {
     throw new ApiError(401, 'Unauthenticated')
   }
+
+  return session
 }

--- a/utils/log.ts
+++ b/utils/log.ts
@@ -1,0 +1,65 @@
+import { Session } from 'next-auth'
+import { setAssignee } from 'server/actions/InventoryItems'
+import * as MongoDriver from 'server/actions/MongoDriver'
+import UserSchema from 'server/models/User'
+import ItemDefinitionSchema from 'server/models/ItemDefinition'
+import { InventoryItemDocument } from 'server/models/InventoryItem'
+import { Document } from 'mongoose'
+
+/**
+ * Logs when an assignee has been changed for an inventory item
+ * @param actionUser The user assigning the inventory item
+ * @param assigneeId The id of the user being assigned the inventory item
+ * @param inventoryItem The inventory item
+ * @returns Nothing
+ */
+export async function logAssignment(
+  actionUser: Session['user'],
+  assigneeId: string,
+  inventoryItem: Awaited<ReturnType<typeof setAssignee>>
+) {
+  if (inventoryItem === null) {
+    return
+  }
+
+  const itemDef = await MongoDriver.getEntity(
+    ItemDefinitionSchema,
+    inventoryItem.itemDefinition as string
+  )
+  if (assigneeId) {
+    const assignee = await MongoDriver.getEntity(UserSchema, assigneeId)
+    console.info(
+      `${actionUser.name} has assigned "${itemDef.name}" (${inventoryItem._id}) to ${assignee.name}`
+    )
+  } else {
+    console.info(
+      `${actionUser.name} has cleared the assignment for "${itemDef.name}" (${inventoryItem._id})`
+    )
+  }
+}
+
+export async function logInventoryItemSoftDeletion(
+  actionUser: Session['user'],
+  inventoryItem: Awaited<
+    ReturnType<typeof MongoDriver.softDeleteEntity<InventoryItemDocument>>
+  >
+) {
+  const itemDef = await MongoDriver.getEntity(
+    ItemDefinitionSchema,
+    inventoryItem.itemDefinition as string
+  )
+  console.info(
+    `${actionUser.name} has soft-deleted inventory item "${itemDef.name}" (${inventoryItem._id})`
+  )
+}
+
+export async function logSoftDeletion<
+  TSchema extends Document & { name: string }
+>(
+  actionUser: Session['user'],
+  entity: Awaited<ReturnType<typeof MongoDriver.softDeleteEntity<TSchema>>>
+) {
+  console.info(
+    `${actionUser.name} has soft-deleted "${entity.name}" (${entity._id}) from ${entity.collection.collectionName}`
+  )
+}


### PR DESCRIPTION
- add `utils/log.ts` file for common logging actions
- assinging an inventory item is logged
- soft-deleting a invnetory item, item def, category, and attribute are now all logged
- have `MongoDriver` return soft deleted entity
- have `serverAuth` return session
- have `setAssignee` return inventory item that was assigned